### PR TITLE
fix: remove broken npm self-upgrade step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
-      - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Description
Remove the `npm install -g npm@latest` step from the release workflow. `npm@10.9.7` (bundled with Node `22.22.2`) crashes on self-upgrade due to a missing `promise-retry` dependency ([npm/cli#9151](https://github.com/npm/cli/issues/9151)).  

This step is unnecessary since `npx semantic-release@25` handles OIDC publishing independently of the system npm version.

---

## Lumos Area
- [x] Config / package / release tooling

---

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## Related Issues
- Fixes the release workflow failure on the `release` branch triggered by the Phase 2 merge (`b7ed6f3`)
- Relates to:
  - [npm/cli#9151](https://github.com/npm/cli/issues/9151)
  - [npm/cli#9152](https://github.com/npm/cli/pull/9152)

---

## How Has This Been Tested?
No local testing required — this removes a CI-only step that crashes before any project code runs. Validation will occur when the workflow re-triggers on merge to `release`.

- [x] `pnpm run validate:all`

### Test Configuration
- Node version: 22 (LTS)
- OS: GitHub Actions `ubuntu-latest`

---

## Checklist
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] My changes generate no new warnings  

---

## Additional Context
The `npm install -g npm@latest` step was originally copied from the `@juspay/neurolink` reference as a safeguard to ensure npm was sufficiently up-to-date for OIDC provenance.

With the `npx semantic-release@25` approach (introduced in Phase 2), this step is redundant. `semantic-release@25` brings its own `@semantic-release/npm@13.x`, which natively supports OIDC.

Node 22’s bundled `npm@10.9.x` already supports `--provenance` for the `npm pack --dry-run` step.

The underlying npm bug ([npm/cli#9152](https://github.com/npm/cli/pull/9152)) was fixed on March 27, but the fix has not yet been included in a Node 22.x release.