### PR TITLE
fix: add prompt size diagnostics to pinpoint token budget issues

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -174,6 +174,19 @@ export class LumosOrchestrator {
       `Invoking AI agent with ${failures.length} failure(s) to analyze...`
     );
 
+    // Prompt size diagnostics -- helps pinpoint token budget issues
+    const systemPromptChars = this.systemPrompt.length;
+    const userMessageChars = userMessage.length;
+    const combinedChars = systemPromptChars + userMessageChars;
+    logger.info(
+      `[Lumos] Prompt size diagnostics:\n` +
+        `  System prompt: ${systemPromptChars} chars (~${Math.round(systemPromptChars / 4)} estimated tokens)\n` +
+        `  User message: ${userMessageChars} chars (~${Math.round(userMessageChars / 4)} estimated tokens)\n` +
+        `  Combined text: ${combinedChars} chars (~${Math.round(combinedChars / 4)} estimated tokens)\n` +
+        `  Failures: ${failures.length}\n` +
+        `  (Note: tool definitions add additional tokens on top of this -- check NeuroLink TokenBudget log for full breakdown)`
+    );
+
     const MAX_ATTEMPTS = 2;
     const startTime = new Date();
 


### PR DESCRIPTION
## Description
Add prompt size diagnostic logging before the `neurolink.generate()` call in the orchestrator. Jenkins is hitting `prompt is too long: 223325 tokens > 200000 maximum` with 33 Playwright failures, and we need hard numbers to identify exactly where the tokens are going (system prompt, user message, memory bank, tool definitions) before deciding on a fix.
## Lumos Area
- [x] AI prompt / analysis flow
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
## Related Issues
- Relates to the 200k token limit breach when analyzing 33 Playwright failures in the Lighthouse Jenkins pipeline
## How Has This Been Tested?
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm run validate:all`
**Test Configuration**:
- Node version: 22
- OS: macOS (Apple Silicon)
- All 10 unit tests pass. Diagnostic log confirmed visible in test output.
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I updated the memory bank if project behavior or architecture changed
## Expected Jenkins Output
After this is released and Lighthouse picks up the new version, the Jenkins console will show:
Lumos Prompt size diagnostics:
  System prompt: XXXXX chars (~XXXXX estimated tokens)
  User message: XXXXX chars (XXXXX estimated tokens)
  Combined text: XXXXX chars (XXXXX estimated tokens)
  Failures: 33
  (Note: tool definitions add additional tokens on top of this -- check NeuroLink TokenBudget log for full breakdown)
NeuroLink 9.44.1 also logs `[TokenBudget] Token breakdown` with per-component token counts (system, tools, history, currentPrompt, total, budget). Together these two logs will pinpoint the exact source of the 223k token overshoot.
## Additional Context
The build will still fail on the token limit -- this is a diagnostic-only change. Once we have the numbers, the next PR will address the actual fix (likely tool filtering via `toolFilter` + `skipToolPromptInjection`, tighter per-line stack trace truncation, or a combination).