### PR TITLE
fix: resolve duplicate comments and verification failures for find-by…

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -6,50 +6,53 @@ content below this comment block. Keep under 60 lines. -->
 
 ## Current Focus
 
-Branch-based PR discovery feature (`find-by-branch`) — matching Yama's pattern.
-When Jenkins' `CHANGE_ID` is unavailable (PR ID is `0` or empty), Lumos now
-instructs the AI to discover the PR from the branch name using
-`list_pull_requests` MCP tool.
+Fix duplicate comment posting when using `find-by-branch` PR discovery.
+Branch: `fix/find-by-branch-verification`. Pushed to fork, pending PR + merge.
 
-### What Changed
+### What Changed (this branch)
 
-- `orchestrator.ts`: PR ID `0`/empty + branch available -> sets
-  `pullRequestId = 'find-by-branch'`, passes `branch` to user message.
-  Fallback REST posting guarded to skip when PR ID is non-numeric.
-- `system-prompt.ts`: Added `list_pull_requests` to AVAILABLE TOOLS. Workflow
-  step 1 now branches: numeric ID -> `get_pull_request` directly,
-  `find-by-branch` -> `list_pull_requests` first to discover PR. User message
-  includes `Branch:` metadata when available.
-- `.prettierignore`: Added `.claude` directory.
+- `orchestrator.ts`: Three fixes for the duplicate comment bug:
+  1. `readToolSuccess()` now handles MCP `CallToolResult` format -- parses
+     `content[].text` JSON string, checks nested `comment.id` as success indicator.
+  2. Added `extractDiscoveredPrId()` -- scans tool call args (`add_comment`,
+     `get_pull_request`, `get_pull_request_diff`) for the numeric `pull_request_id`
+     the AI discovered. Updates local `pullRequestId` from `"find-by-branch"` to
+     the real numeric ID.
+  3. Fallback posting guard now reads local `pullRequestId` (which may have been
+     updated with discovered ID) instead of `options.pullRequestId` (original
+     undefined/`'0'`). Also explicitly excludes `"find-by-branch"` string.
 
-### Context: Why This Was Needed
+### What Changed (Lighthouse side, uncommitted by user)
 
-Jenkins pipeline run on PR #4638 passed `--pr-id 0` (because `CHANGE_ID` was
-unavailable). Lumos called `get_pull_request` with ID 0, got no useful PR
-context, and the AI produced a shallow 245-token response with 0 comments.
+- `lumos.config.yaml`: `ai.maxTokens` changed from `8192` to `30000` for
+  headroom on larger failure sets.
 
 ## Recent Decisions
 
-- **Match Yama's `find-by-branch` pattern**: AI-driven PR discovery via prompt
-  instruction, not programmatic Bitbucket API call. Consistent with Yama's
-  `PromptBuilder.js` approach.
-- **No Jenkinsfile changes needed**: `--pr-id 0` from Jenkins is handled by
-  Lumos internally. The branch name (`--branch`) is already passed.
-- **Fallback posting disabled for `find-by-branch`**: The orchestrator's REST
-  API fallback can't work without a numeric PR ID. If the AI discovers the PR
-  and posts via MCP, that's fine. If not, fallback is skipped.
+- **maxTokens 8192 was not the root cause of shallow analysis**: Jenkins build
+  26 produced full detailed comments with 8192. Changed to 30000 anyway as
+  safety margin for complex failure sets.
+- **Duplicate comments are the real problem**: Build 26 posted two nearly
+  identical Lumos comments (IDs 1162645, 1162647) 2 minutes apart, costing
+  ~$1.00 instead of ~$0.50.
+- **Fix approach**: Extract discovered PR ID from tool call args rather than
+  adding programmatic Bitbucket API calls. The AI already discovers and uses
+  the real PR ID -- we just need to read it back from `toolResults`.
 
-## Completed Recently
+## npm Version History
 
-- OIDC fix merged to `release`, `@juspay/lumos@1.0.1` published to npm
-- Lighthouse updated to `^1.0.1`, lockfile regenerated
-- First Jenkins pipeline run: MCP servers registered, report parsed, AI invoked
-  (but PR ID `0` caused shallow analysis — fixed by this PR)
+| Version | Contents                        | Published via |
+| ------- | ------------------------------- | ------------- |
+| 1.0.0   | Initial release                 | Manual        |
+| 1.0.1   | MCP binary fix                  | OIDC auto     |
+| 1.1.0   | find-by-branch PR discovery     | OIDC auto     |
+| 1.1.1   | Prompt size diagnostic logging  | OIDC auto     |
+| 1.1.2   | Duplicate comment fix (pending) | --            |
 
 ## Next Steps
 
-1. Merge this PR (`feat/find-pr-by-branch`) to `release`
-2. semantic-release publishes new version (1.1.0)
-3. Update Lighthouse lockfile to pick up new version
-4. Re-run Jenkins build on PR #4638 — AI should discover PR and do full analysis
-5. Update PR #4638 description on Bitbucket
+1. Create GitHub PR for `fix/find-by-branch-verification` -> `release`
+2. Merge -> semantic-release publishes `1.1.2`
+3. Update Lighthouse `package.json` to `"@juspay/lumos": "^1.1.2"`, regen lockfile
+4. User commits maxTokens change + dep bump on Lighthouse PR #4638
+5. Re-run Jenkins build to validate: single comment, no duplicates

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -64,10 +64,10 @@ in the Section Index. -->
 
 ## npm Publishing Configuration
 
-**Status**: `@juspay/lumos@1.0.0` published to npm (by Sachin, manually).
-OIDC automated publishing failed with `ENEEDAUTH`. Root cause identified:
-missing npm@11 upgrade step. Fix applied to `release.yml` (uncommitted, 3
-changes). Once pushed and merged, semantic-release will publish 1.1.0.
+**Status**: Complete. `@juspay/lumos` published to npm via automated OIDC
+pipeline. Versions: 1.0.0 (manual), 1.0.1 (MCP binary fix), 1.1.0
+(find-by-branch), 1.1.1 (prompt diagnostics). All automated publishes via
+semantic-release on push to `release` branch.
 
 **Original problem**: Lighthouse PR #4638 had `"@juspay/lumos": "github:juspay/lumos"`
 in `package.json`. GitHub installs don't build `dist/` (the `prepare` script was
@@ -109,7 +109,7 @@ path (`join(process.cwd(), 'node_modules/.bin/...')`). Moved MCP server packages
 from `devDependencies` to `dependencies`. Locally verified with
 `pnpm test:local -- --pr 4638`.
 
-### Phase 6 -- ENEEDAUTH Root Cause + Fix (uncommitted)
+### Phase 6 -- ENEEDAUTH Root Cause + Fix (merged, v1.0.1 published)
 
 Release workflow ran after Phase 5 merge but `npm publish` failed with
 `ENEEDAUTH`. Deep investigation of `@semantic-release/npm@13.1.5` source:
@@ -123,11 +123,41 @@ Release workflow ran after Phase 5 merge but `npm publish` failed with
 Sachin confirmed trusted publisher was already configured on npmjs.com.
 The actual missing piece was the npm@11 upgrade step (neurolink has it).
 
-**3 fixes applied to `release.yml`** (uncommitted):
+**3 fixes applied to `release.yml`** (merged):
 
 1. Added `npx -y npm@11 install -g npm@11` (pinned, not `npm@latest`)
 2. Changed `npx semantic-release@25` -> `npx semantic-release` (use local version)
 3. Added job-level `permissions` block (matching neurolink's belt-and-suspenders)
+
+After merge, `@juspay/lumos@1.0.1` published automatically via OIDC pipeline.
+
+### Phase 7 -- find-by-branch PR Discovery (merged, v1.1.0 published)
+
+When Jenkins' `CHANGE_ID` is unavailable (PR ID is `0` or empty), Lumos
+instructs the AI to discover the PR from the branch name using
+`list_pull_requests` MCP tool. Matches Yama's `PromptBuilder.js` pattern.
+
+Changes: `orchestrator.ts` (PR ID resolution), `system-prompt.ts` (workflow
+branching + `list_pull_requests` tool docs), `.prettierignore`.
+
+### Phase 8 -- Prompt Size Diagnostics (merged, v1.1.1 published)
+
+Added diagnostic logging before the `generate()` call: system prompt chars,
+user message chars, combined chars, estimated tokens (chars/4 heuristic),
+failure count. Helps pinpoint token budget issues from Jenkins logs.
+
+### Phase 9 -- Duplicate Comment Fix (in PR, pending merge)
+
+Branch: `fix/find-by-branch-verification`. Three root causes for duplicate
+comments when using find-by-branch:
+
+1. `readToolSuccess()` couldn't parse MCP `CallToolResult` format
+   (`{ content: [{ type: 'text', text: '<JSON>' }] }`). Added JSON parsing
+   of `content[].text` and `comment.id` nested object check.
+2. After AI discovers real PR ID via `list_pull_requests`, orchestrator never
+   extracted it back. Added `extractDiscoveredPrId()` to scan tool call args.
+3. Fallback posting guard read `options.pullRequestId` (original undefined)
+   instead of local `pullRequestId` (updated with discovered ID).
 
 ## Test Validation Results
 
@@ -154,6 +184,25 @@ The actual missing piece was the npm@11 upgrade step (neurolink has it).
 - **Final run (after all V1.1 fixes)**: 17 failures. 10 PR-caused + 5 flaky +
   3 infra. 250k tokens, $0.83, 210.8s. Comment posted first attempt, old Lumos
   comments deleted via dedup.
+
+### PR 4638 -- Jenkins Pipeline Runs (real CI, Vertex AI + Claude Sonnet 4.5)
+
+- **Build 21** (2026-04-09): 212 tests, 156 passed, 35 failed, 3 flaky.
+- **Build 23** (2026-04-09): 212 tests, 162 passed, 33 failed, 0 flaky.
+- **Build 26** (2026-04-10): 252 tests, 197 passed, 38 failed, 0 flaky. Lumos
+  posted TWO full analysis comments (duplicate due to verification bug). Each
+  comment covered all 38 failures with correct root cause analysis, grouped by
+  the 4 intentional test ID renames, with before/after code snippets and
+  specific file+line fix suggestions. AI used `list_pull_requests` ->
+  `get_pull_request` -> file reading -> `add_comment`. 164k input tokens,
+  ~$0.50 per attempt. The duplicate was caused by the `find-by-branch`
+  verification bug (fixed in Phase 9).
+
+**Key finding from Build 26**: The `maxTokens: 8192` in Lighthouse config
+was sufficient for this run (AI produced ~359 output tokens of tool calls +
+a full comment via MCP). Earlier concern about shallow analysis was from a
+different build with different conditions. Changed to `maxTokens: 30000`
+anyway for safety margin on larger failure sets.
 
 ### PR 4598 (8 detailed runs testing V1.1 enhancements)
 
@@ -203,30 +252,31 @@ Key findings across all runs:
 
 ## Remaining Work Table
 
-| Task                               | Repo       | Status      | Blocked?             |
-| ---------------------------------- | ---------- | ----------- | -------------------- |
-| npm publish config                 | lumos      | Done        | --                   |
-| semantic-release version upgrade   | lumos      | Done        | --                   |
-| npm self-upgrade crash fix         | lumos      | Done        | --                   |
-| Manual first publish (v1.0.0)      | lumos      | Done        | --                   |
-| MCP binary fix (local binary path) | lumos      | Done        | --                   |
-| OIDC fix (npm@11 + release.yml)    | lumos      | Done        | --                   |
-| Automated npm publish (v1.0.1)     | lumos      | Done        | --                   |
-| find-by-branch PR discovery        | lumos      | In PR       | --                   |
-| Lighthouse PR dep `^1.0.1`         | lighthouse | Done        | --                   |
-| Lighthouse lockfile regen          | lighthouse | Done        | --                   |
-| Lighthouse lockfile regen (1.1.0)  | lighthouse | Pending     | find-by-branch merge |
-| Lighthouse PR #4638 description    | lighthouse | Pending     | Lockfile regen       |
-| `scripts/run-lumos.js`             | lighthouse | Done        | --                   |
-| `lumos.config.yaml` in Lighthouse  | lighthouse | Done        | --                   |
-| `package.json` dep addition        | lighthouse | Done        | --                   |
-| Jenkinsfile mock tests catch block | lighthouse | Done        | --                   |
-| Jenkinsfile beta catch block       | lighthouse | Deferred    | Validate mock first  |
-| Jenkinsfile AI sanity catch block  | lighthouse | Deferred    | Validate mock first  |
-| `orchestrator.test.ts` type fixes  | lumos      | Done        | --                   |
-| Fix `hasCritical` false positive   | lumos      | Pending     | No                   |
-| Two-pass analysis                  | lumos      | Not started | No                   |
-| Structured output wiring           | lumos      | Not started | No                   |
+| Task                               | Repo       | Status       | Blocked?            |
+| ---------------------------------- | ---------- | ------------ | ------------------- |
+| npm publish config                 | lumos      | Done         | --                  |
+| semantic-release version upgrade   | lumos      | Done         | --                  |
+| npm self-upgrade crash fix         | lumos      | Done         | --                  |
+| Manual first publish (v1.0.0)      | lumos      | Done         | --                  |
+| MCP binary fix (local binary path) | lumos      | Done (1.0.1) | --                  |
+| OIDC fix (npm@11 + release.yml)    | lumos      | Done (1.0.1) | --                  |
+| Automated npm publish (v1.0.1)     | lumos      | Done         | --                  |
+| find-by-branch PR discovery        | lumos      | Done (1.1.0) | --                  |
+| Prompt size diagnostics            | lumos      | Done (1.1.1) | --                  |
+| find-by-branch verification fix    | lumos      | In PR        | Pending merge       |
+| Lighthouse PR dep `^1.1.1`         | lighthouse | Done         | --                  |
+| Lighthouse lockfile regen          | lighthouse | Done         | --                  |
+| Lighthouse maxTokens 8192->30000   | lighthouse | Done         | User commit pending |
+| `scripts/run-lumos.js`             | lighthouse | Done         | --                  |
+| `lumos.config.yaml` in Lighthouse  | lighthouse | Done         | --                  |
+| `package.json` dep addition        | lighthouse | Done         | --                  |
+| Jenkinsfile mock tests catch block | lighthouse | Done         | --                  |
+| Jenkinsfile beta catch block       | lighthouse | Deferred     | Validate mock first |
+| Jenkinsfile AI sanity catch block  | lighthouse | Deferred     | Validate mock first |
+| `orchestrator.test.ts` type fixes  | lumos      | Done         | --                  |
+| Fix `hasCritical` false positive   | lumos      | Pending      | No                  |
+| Two-pass analysis                  | lumos      | Not started  | No                  |
+| Structured output wiring           | lumos      | Not started  | No                  |
 
 ## Known Issues and Tech Debt
 
@@ -234,6 +284,13 @@ Key findings across all runs:
   falls back to `responseText` scanning which can match "PR-caused" in
   non-critical context. Runs 1, 3, 7 had false positives; runs 2, 4, 8 were
   correct. Not yet fixed.
+- **Duplicate comments on find-by-branch (FIXING)**: When PR ID is discovered
+  via branch, orchestrator couldn't verify the MCP `add_comment` succeeded,
+  causing a retry that posted a second identical comment. Fix in PR on branch
+  `fix/find-by-branch-verification`. Three root causes: MCP response parsing,
+  PR ID extraction, fallback guard variable.
+- **`posting.strategy: 'per-failure'` is dead code**: The config option exists
+  in the Zod schema but is never implemented. Only `'single'` works.
 - **Fixtures not committed**: `fixtures/result-{4598,4610,4571,4638}.json` are
   gitignored (large, contain real test data). Local-only for development.
 - **`as never` cast**: `addExternalMCPServer` options use `as never` to bypass

--- a/memory-bank/projectBrief.md
+++ b/memory-bank/projectBrief.md
@@ -8,7 +8,7 @@ technical details. Changes only when the project's fundamental scope shifts. -->
 
 - **Name**: Lumos
 - **Package**: `@juspay/lumos`
-- **Version**: 1.0.0
+- **Version**: 1.1.1 (latest published; 1.1.2 pending with verification fix)
 - **Repo**: `github.com/juspay/lumos`
 - **Branch**: `release`
 - **Language**: TypeScript (strict, ESM, Node >= 20.12)

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -135,6 +135,63 @@ each failure's spec file, title, error message, error location, truncated
 stack trace (30 lines max, 2000 chars max), and retry info formatted as
 "X/Y failed" (e.g., "2/3 failed").
 
+## MCP Tool Result Verification
+
+After the AI calls MCP tools, the orchestrator needs to determine if
+`add_comment` succeeded. The verification chain in `readToolSuccess()`:
+
+```
+AI SDK toolResult object
+  { type: 'tool-result', toolCallId, toolName, args, result }
+                                                       |
+                                                       v
+  MCP CallToolResult (the `result` field)
+  { content: [{ type: 'text', text: '<JSON string>' }] }
+                                            |
+                                            v
+  Parsed JSON from text field
+  { message: 'Comment added successfully', comment: { id: 12345, ... } }
+                                                            |
+                                                            v
+  readToolSuccess() checks: comment.id is numeric -> return true
+```
+
+Priority of checks in `readToolSuccess()`:
+
+1. `record.success` (boolean)
+2. `record.isError` (boolean, inverted)
+3. `record.status` (string: 'success'/'ok'/'completed' vs 'error'/'failed')
+4. `record.error` (non-null -> failure)
+5. `record.result` (recurse)
+6. `record.commentId` or `record.id` (presence -> success)
+7. `record.comment.id` (nested object -> success)
+8. `record.content[]` (MCP format: parse JSON from text entries, recurse)
+
+If `readToolSuccess()` returns `undefined` (indeterminate), the orchestrator
+falls back to `verifyCommentPosted()` which calls the Bitbucket REST API to
+check if the comment text appears on the PR.
+
+## PR ID Discovery for find-by-branch
+
+When `pullRequestId` starts as `"find-by-branch"`, the AI discovers the real
+numeric PR ID via `list_pull_requests` and uses it in subsequent tool calls.
+The orchestrator extracts this discovered ID from `toolResults`:
+
+```typescript
+// extractDiscoveredPrId() scans tool call args for numeric pull_request_id
+const prToolNames = [
+  'add_comment',
+  'get_pull_request',
+  'get_pull_request_diff',
+];
+// Iterates toolResults, finds first matching tool with numeric args.pull_request_id
+// Returns as string (e.g., '4638') or undefined if not found
+```
+
+This extracted ID is used to update the local `pullRequestId` variable,
+enabling both `verifyCommentPosted()` (REST API check) and `postCommentFallback()`
+(REST API fallback) to work with the correct numeric PR ID.
+
 ## Key Interfaces
 
 ```typescript
@@ -207,22 +264,24 @@ All errors extend `LumosError` and carry a machine-readable `code` plus a
 
 ## Design Decisions
 
-| Decision                                              | Rationale                                                                                                                                                                                                                            |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Autonomous agent (not structured output) for V1       | Agent can fetch files, read code, and reason about context. Structured output would need all context upfront.                                                                                                                        |
-| Single comment (not per-failure)                      | Developers prefer one consolidated comment over N separate ones. Reduces noise.                                                                                                                                                      |
-| `maxFailures` removed (was capped at 10)              | Real PR 4638 had 17 failures; capping at 10 missed 7. Token cost is acceptable (~230k for 17).                                                                                                                                       |
-| Comment dedup via MCP `delete_comment`                | The Bitbucket MCP server DOES have `delete_comment`. AI deletes old Lumos comments as part of its workflow step 2.                                                                                                                   |
-| Memory bank loaded from consumer's project root       | Lighthouse has failure-pattern files that give the AI project-specific context.                                                                                                                                                      |
-| LiteLLM for local, Vertex for prod                    | LiteLLM proxy at `grid.ai.juspay.net` is fast and free for dev. Vertex is the stable production path (same as Yama).                                                                                                                 |
-| Retry loop (MAX_ATTEMPTS=2)                           | AI sometimes stops prematurely without posting. A second attempt usually succeeds.                                                                                                                                                   |
-| Fallback REST posting                                 | If AI fails to call `add_comment` after all retries, orchestrator posts directly via Bitbucket REST API to guarantee the comment reaches the PR.                                                                                     |
-| `hasCritical` detection from posted comment text      | Scan the posted comment for "PR-caused" verdicts. Non-deterministic edge case exists (false positive from response text scanning).                                                                                                   |
-| `totalAttempts` + `failedAttempts` (not `retryCount`) | AI needs to know "2 of 3 attempts failed" not just "3 retries". The old `retryCount` was ambiguous and caused misclassification.                                                                                                     |
-| Typed error hierarchy                                 | Enables callers to `catch` specific error types (e.g., `McpError` vs `ConfigError`) for different handling strategies.                                                                                                               |
-| 3-layer config with Zod                               | YAML for project defaults, env vars for per-run overrides (Jenkins stages), Zod catches invalid config early.                                                                                                                        |
-| Langfuse observability (optional)                     | Traces AI calls for cost monitoring and debugging. Disabled by default; enabled via config or env vars.                                                                                                                              |
-| Branch-based PR discovery (`find-by-branch`)          | Matches Yama's pattern. Jenkins `CHANGE_ID` is unavailable in some contexts (manual trigger, non-multibranch). AI discovers PR via `list_pull_requests` using branch name. Fallback REST posting disabled when PR ID is non-numeric. |
+| Decision                                              | Rationale                                                                                                                                                                                                                                                                                                                                          |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Autonomous agent (not structured output) for V1       | Agent can fetch files, read code, and reason about context. Structured output would need all context upfront.                                                                                                                                                                                                                                      |
+| Single comment (not per-failure)                      | Developers prefer one consolidated comment over N separate ones. Reduces noise.                                                                                                                                                                                                                                                                    |
+| `maxFailures` removed (was capped at 10)              | Real PR 4638 had 17 failures; capping at 10 missed 7. Token cost is acceptable (~230k for 17).                                                                                                                                                                                                                                                     |
+| Comment dedup via MCP `delete_comment`                | The Bitbucket MCP server DOES have `delete_comment`. AI deletes old Lumos comments as part of its workflow step 2.                                                                                                                                                                                                                                 |
+| Memory bank loaded from consumer's project root       | Lighthouse has failure-pattern files that give the AI project-specific context.                                                                                                                                                                                                                                                                    |
+| LiteLLM for local, Vertex for prod                    | LiteLLM proxy at `grid.ai.juspay.net` is fast and free for dev. Vertex is the stable production path (same as Yama).                                                                                                                                                                                                                               |
+| Retry loop (MAX_ATTEMPTS=2)                           | AI sometimes stops prematurely without posting. A second attempt usually succeeds.                                                                                                                                                                                                                                                                 |
+| Fallback REST posting                                 | If AI fails to call `add_comment` after all retries, orchestrator posts directly via Bitbucket REST API to guarantee the comment reaches the PR.                                                                                                                                                                                                   |
+| `hasCritical` detection from posted comment text      | Scan the posted comment for "PR-caused" verdicts. Non-deterministic edge case exists (false positive from response text scanning).                                                                                                                                                                                                                 |
+| `totalAttempts` + `failedAttempts` (not `retryCount`) | AI needs to know "2 of 3 attempts failed" not just "3 retries". The old `retryCount` was ambiguous and caused misclassification.                                                                                                                                                                                                                   |
+| Typed error hierarchy                                 | Enables callers to `catch` specific error types (e.g., `McpError` vs `ConfigError`) for different handling strategies.                                                                                                                                                                                                                             |
+| 3-layer config with Zod                               | YAML for project defaults, env vars for per-run overrides (Jenkins stages), Zod catches invalid config early.                                                                                                                                                                                                                                      |
+| Langfuse observability (optional)                     | Traces AI calls for cost monitoring and debugging. Disabled by default; enabled via config or env vars.                                                                                                                                                                                                                                            |
+| Branch-based PR discovery (`find-by-branch`)          | Matches Yama's pattern. Jenkins `CHANGE_ID` is unavailable in some contexts (manual trigger, non-multibranch). AI discovers PR via `list_pull_requests` using branch name. Fallback REST posting disabled when PR ID is non-numeric.                                                                                                               |
+| Extract discovered PR ID from tool call args          | After AI discovers the real PR via `list_pull_requests` and uses it in `get_pull_request`/`add_comment`, the orchestrator extracts the numeric ID from `toolResults[].args.pull_request_id`. This enables REST API verification and fallback posting to work correctly for find-by-branch scenarios.                                               |
+| MCP tool result verification via `readToolSuccess()`  | MCP servers return `CallToolResult` format: `{ content: [{ type: 'text', text: '<JSON>' }] }`. The `readToolSuccess()` method now parses the embedded JSON and checks for `comment.id` (nested under a `comment` object) as a success indicator. Without this, all MCP tool results appeared as "indeterminate" and triggered unnecessary retries. |
 
 ## Release & Publishing Pattern
 
@@ -293,7 +352,8 @@ the version-bump commit. This matches neurolink's ordering.
 - First version must be published manually (OIDC cannot create new packages)
 
 **Version history**: v1.0.0 published manually by Sachin. Automated OIDC
-publishing will produce v1.1.0+ once the release.yml fixes are merged.
+publishing produces subsequent versions: v1.0.1 (MCP binary fix), v1.1.0
+(find-by-branch), v1.1.1 (prompt diagnostics).
 
 ### Jira Prefix Stripping
 

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -247,6 +247,16 @@ npx tsx scripts/test-local.ts --live --pr 4638
 # Verify package contents before publish
 npm pack --dry-run                        # lists files + size (should be ~34.5 kB, 40 files)
 
-# In Jenkins (via Lighthouse) -- not yet integrated
-node scripts/run-lumos.js --type=mock --pr-id=${prId} --workspace=BZ --repository=lighthouse
+# In Jenkins (via Lighthouse Jenkinsfile mock tests catch block)
+pnpm run lumos:analyze --type mock --pr-id ${prId} --workspace BZ --repository lighthouse --branch ${env.BRANCH_NAME}
 ```
+
+## npm Version History
+
+| Version | Date    | Key Changes                                                | Commit prefix |
+| ------- | ------- | ---------------------------------------------------------- | ------------- |
+| 1.0.0   | 2026-03 | Initial release (manual publish by Sachin)                 | --            |
+| 1.0.1   | 2026-04 | MCP binary fix (local path), OIDC pipeline fix (npm@11)    | fix           |
+| 1.1.0   | 2026-04 | find-by-branch PR discovery                                | feat          |
+| 1.1.1   | 2026-04 | Prompt size diagnostic logging                             | feat          |
+| 1.1.2   | pending | Duplicate comment fix (MCP verification, PR ID extraction) | fix           |

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -287,6 +287,16 @@ export class LumosOrchestrator {
       // -- Extract posted comment from tool results --------------------------
       postState = this.extractCommentInfo(toolResults, toolsUsed);
 
+      // If we started with "find-by-branch", try to recover the real numeric
+      // PR ID from the tool call args so verification and fallback work.
+      if (pullRequestId === 'find-by-branch') {
+        const discoveredId = this.extractDiscoveredPrId(toolResults);
+        if (discoveredId) {
+          logger.info(`Discovered real PR ID from tool calls: ${discoveredId}`);
+          pullRequestId = discoveredId;
+        }
+      }
+
       const commentCandidate =
         postState.attemptedCommentText ??
         this.extractLumosComment(responseText) ??
@@ -358,8 +368,10 @@ export class LumosOrchestrator {
     // -- Fallback: post comment directly if AI composed but didn't post ------
     let fallbackPosted = false;
     const numericPrId =
-      options.pullRequestId && options.pullRequestId !== '0'
-        ? options.pullRequestId
+      pullRequestId &&
+      pullRequestId !== '0' &&
+      pullRequestId !== 'find-by-branch'
+        ? pullRequestId
         : undefined;
     if (!postState.verifiedPosted && !options.dryRun && numericPrId) {
       const extractedComment =
@@ -483,6 +495,51 @@ export class LumosOrchestrator {
     return toolState;
   }
 
+  /**
+   * Scan tool results for a numeric pull_request_id in the args of any
+   * Bitbucket tool call (add_comment, get_pull_request, etc.). Used to
+   * recover the real PR ID when the orchestrator started with
+   * "find-by-branch".
+   */
+  private extractDiscoveredPrId(
+    toolResults: unknown[] | undefined
+  ): string | undefined {
+    if (!toolResults || !Array.isArray(toolResults)) {
+      return undefined;
+    }
+
+    const prToolNames = [
+      'add_comment',
+      'get_pull_request',
+      'get_pull_request_diff',
+    ];
+
+    for (const tr of toolResults) {
+      if (!tr || typeof tr !== 'object' || !('toolName' in tr)) {
+        continue;
+      }
+      const toolName = (tr as Record<string, unknown>).toolName;
+      if (
+        typeof toolName !== 'string' ||
+        !prToolNames.some((name) => toolName.includes(name))
+      ) {
+        continue;
+      }
+      const args = (tr as Record<string, unknown>).args as
+        | Record<string, unknown>
+        | undefined;
+      const prId = args?.pull_request_id;
+      if (typeof prId === 'number' && prId > 0) {
+        return String(prId);
+      }
+      if (typeof prId === 'string' && /^\d+$/.test(prId)) {
+        return prId;
+      }
+    }
+
+    return undefined;
+  }
+
   private isSuccessfulAddCommentToolResult(
     toolResult: Record<string, unknown>
   ): boolean {
@@ -530,6 +587,38 @@ export class LumosOrchestrator {
       typeof record.id === 'string'
     ) {
       return true;
+    }
+
+    // Check nested comment object (MCP add_comment returns { comment: { id } })
+    if (record.comment && typeof record.comment === 'object') {
+      const comment = record.comment as Record<string, unknown>;
+      if (typeof comment.id === 'number' || typeof comment.id === 'string') {
+        return true;
+      }
+    }
+
+    // Handle MCP CallToolResult format: { content: [{ type: 'text', text: '<JSON>' }] }
+    if (Array.isArray(record.content)) {
+      for (const entry of record.content) {
+        if (
+          entry &&
+          typeof entry === 'object' &&
+          (entry as Record<string, unknown>).type === 'text' &&
+          typeof (entry as Record<string, unknown>).text === 'string'
+        ) {
+          try {
+            const parsed = JSON.parse(
+              (entry as Record<string, unknown>).text as string
+            );
+            const nested = this.readToolSuccess(parsed);
+            if (nested !== undefined) {
+              return nested;
+            }
+          } catch {
+            // Not valid JSON, skip
+          }
+        }
+      }
     }
 
     return undefined;


### PR DESCRIPTION
## Description
Fixes duplicate comment posting when using `find-by-branch` PR discovery.
When `pullRequestId` is `"find-by-branch"`, the orchestrator could not verify that `add_comment` succeeded via MCP, causing unnecessary retries and duplicate comments on every run. This was observed on PR #4638 (build 26) where two nearly identical Lumos analysis comments were posted 2 minutes apart, doubling the cost (~$1.00 instead of ~$0.50).
**Three root causes fixed:**
1. **`readToolSuccess()` didn't understand MCP `CallToolResult` format** — The MCP server returns `{ content: [{ type: 'text', text: '<JSON>' }] }`, but `readToolSuccess()` had no handler for this shape. It always returned `undefined`, so `isSuccessfulAddCommentToolResult()` treated every MCP `add_comment` as "indeterminate". Now parses the embedded JSON string and checks for `comment.id` as a success indicator.
2. **Discovered PR ID was never extracted back** — The AI discovers the real numeric PR ID via `list_pull_requests` and uses it in `get_pull_request` / `add_comment` calls, but the orchestrator's local `pullRequestId` stayed as `"find-by-branch"`. This caused `verifyCommentPosted()` to construct an invalid REST URL (`/pull-requests/find-by-branch/comments`) which always returned a 404. Added `extractDiscoveredPrId()` to scan `toolResults[].args.pull_request_id` from `add_comment`, `get_pull_request`, and `get_pull_request_diff` tool calls.
3. **Fallback posting guard read the wrong variable** — `numericPrId` was derived from `options.pullRequestId` (the original caller value, typically `undefined` or `'0'` for find-by-branch) instead of the local `pullRequestId` variable that gets updated with the discovered ID. Also added explicit exclusion of the `"find-by-branch"` string.
## Lumos Area
- [x] Bitbucket or Jira integration
- [x] Comment posting / retry / fallback logic
- [x] Documentation / memory bank
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
## Related Issues
- Relates to Lighthouse PR #4638 (BZ-1364)
## How Has This Been Tested?
- [x] `pnpm lint`
- [x] `pnpm typecheck`
**Test Configuration**:
- Node version: 22
- OS: macOS (Apple Silicon)
- Verified via: `pnpm build` clean, lint-staged + commitlint + typecheck all passed on commit
**Behavioral verification**: The duplicate comment behavior was observed on Lighthouse PR #4638 Jenkins build 26 (comment IDs 1162645 and 1162647). After this fix, the verification chain will be:
1. `readToolSuccess()` parses MCP response JSON → finds `comment.id` → returns `true`
2. `extractCommentInfo()` sets `verifiedPosted: true` on first attempt
3. `isRunIncomplete()` returns `false` → no retry → no duplicate
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I updated the memory bank if project behavior or architecture changed
## Additional Context
**Files changed:**
- `src/orchestrator.ts` — 3 surgical changes (91 insertions, 2 deletions)
- `memory-bank/*.md` — 5 files updated with v1.1.x progress, Jenkins validation results, and verification fix documentation
**New method added:** `extractDiscoveredPrId(toolResults)` — scans tool call args for numeric `pull_request_id` from `add_comment`, `get_pull_request`, or `get_pull_request_diff` tool results. Returns the first valid numeric ID as a string, or `undefined`.
**`readToolSuccess()` new checks added (in priority order after existing checks):**
1. `record.comment.id` — nested comment object with numeric/string ID
2. `record.content[]` — MCP `CallToolResult` format: iterates text entries, parses JSON, recurses