### PR TITLE
feat: resolve PR by branch, inject prior-run context, and post safe-t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ npm-debug.log*
 
 # Test fixtures (local only, contain real report data)
 fixtures/
+CLAUDE.md

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -6,53 +6,45 @@ content below this comment block. Keep under 60 lines. -->
 
 ## Current Focus
 
-Fix duplicate comment posting when using `find-by-branch` PR discovery.
-Branch: `fix/find-by-branch-verification`. Pushed to fork, pending PR + merge.
+Lighthouse PR #4638 cleanup + Lumos Task 2/3 planning.
+Branch (Lumos): `fix/orchestrator-delete-old-comments` (merged to upstream, v1.1.3).
+Branch (Lighthouse): `BZ-1364-run-lumos-v-1-capability-verification` targeting `beta`.
 
-### What Changed (this branch)
+### What Changed (this session)
 
-- `orchestrator.ts`: Three fixes for the duplicate comment bug:
-  1. `readToolSuccess()` now handles MCP `CallToolResult` format -- parses
-     `content[].text` JSON string, checks nested `comment.id` as success indicator.
-  2. Added `extractDiscoveredPrId()` -- scans tool call args (`add_comment`,
-     `get_pull_request`, `get_pull_request_diff`) for the numeric `pull_request_id`
-     the AI discovered. Updates local `pullRequestId` from `"find-by-branch"` to
-     the real numeric ID.
-  3. Fallback posting guard now reads local `pullRequestId` (which may have been
-     updated with discovered ID) instead of `options.pullRequestId` (original
-     undefined/`'0'`). Also explicitly excludes `"find-by-branch"` string.
+- **v1.1.3 shipped**: Orchestrator-level comment cleanup, removed
+  `readToolSuccess()`/`extractDiscoveredPrId()`/`verifyCommentPosted()`,
+  simplified `CommentPostState` and `extractCommentInfo()`, fixed
+  `isRunIncomplete()` no-action signal false positive.
+- **Lighthouse Svelte reverts staged**: 4 files reverted to `beta` state
+  (HomeView, analytics, order, integration pages). Awaiting user commit.
+- **PR #4638 description updated**: Posted via Bitbucket DC REST API (PUT),
+  version 191, 49 reviewers preserved.
 
-### What Changed (Lighthouse side, uncommitted by user)
+### Recent Decisions
 
-- `lumos.config.yaml`: `ai.maxTokens` changed from `8192` to `30000` for
-  headroom on larger failure sets.
-
-## Recent Decisions
-
-- **maxTokens 8192 was not the root cause of shallow analysis**: Jenkins build
-  26 produced full detailed comments with 8192. Changed to 30000 anyway as
-  safety margin for complex failure sets.
-- **Duplicate comments are the real problem**: Build 26 posted two nearly
-  identical Lumos comments (IDs 1162645, 1162647) 2 minutes apart, costing
-  ~$1.00 instead of ~$0.50.
-- **Fix approach**: Extract discovered PR ID from tool call args rather than
-  adding programmatic Bitbucket API calls. The AI already discovers and uses
-  the real PR ID -- we just need to read it back from `toolResults`.
+- **Orchestrator-level cleanup over AI-driven dedup**: `deletePreviousLumosComments()`
+  runs before each attempt via Bitbucket REST API, not relying on AI to delete.
+- **Yama inline suggestion not worth implementing**: Wrapping `import { createLumos }`
+  in try-catch is unnecessary -- Jenkinsfile already wraps the entire call.
+- **No max failure cap**: User explicitly rejected capping failures.
 
 ## npm Version History
 
-| Version | Contents                        | Published via |
-| ------- | ------------------------------- | ------------- |
-| 1.0.0   | Initial release                 | Manual        |
-| 1.0.1   | MCP binary fix                  | OIDC auto     |
-| 1.1.0   | find-by-branch PR discovery     | OIDC auto     |
-| 1.1.1   | Prompt size diagnostic logging  | OIDC auto     |
-| 1.1.2   | Duplicate comment fix (pending) | --            |
+| Version | Contents                                        | Published via |
+| ------- | ----------------------------------------------- | ------------- |
+| 1.0.0   | Initial release                                 | Manual        |
+| 1.0.1   | MCP binary fix                                  | OIDC auto     |
+| 1.1.0   | find-by-branch PR discovery                     | OIDC auto     |
+| 1.1.1   | Prompt size diagnostic logging                  | OIDC auto     |
+| 1.1.2   | Duplicate comment fix (MCP verification, PR ID) | OIDC auto     |
+| 1.1.3   | Orchestrator cleanup, no-action signal fix      | OIDC auto     |
 
 ## Next Steps
 
-1. Create GitHub PR for `fix/find-by-branch-verification` -> `release`
-2. Merge -> semantic-release publishes `1.1.2`
-3. Update Lighthouse `package.json` to `"@juspay/lumos": "^1.1.2"`, regen lockfile
-4. User commits maxTokens change + dep bump on Lighthouse PR #4638
-5. Re-run Jenkins build to validate: single comment, no duplicates
+1. Implement Task 3: Orchestrator-level PR lookup by branch (resolve
+   `find-by-branch` to numeric PR ID via Bitbucket REST API before AI call)
+2. Implement Task 2: Post "safe to merge" comment when 0 failures (depends
+   on Task 3 for numeric PR ID)
+3. User commits Lighthouse Svelte reverts + Jenkinsfile `--verbose` flag
+4. Clean up old Lumos comments on PR #4638 (blocked until Task 3 lands)

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -146,7 +146,7 @@ Added diagnostic logging before the `generate()` call: system prompt chars,
 user message chars, combined chars, estimated tokens (chars/4 heuristic),
 failure count. Helps pinpoint token budget issues from Jenkins logs.
 
-### Phase 9 -- Duplicate Comment Fix (in PR, pending merge)
+### Phase 9 -- Duplicate Comment Fix (Done, v1.1.2)
 
 Branch: `fix/find-by-branch-verification`. Three root causes for duplicate
 comments when using find-by-branch:
@@ -158,6 +158,26 @@ comments when using find-by-branch:
    extracted it back. Added `extractDiscoveredPrId()` to scan tool call args.
 3. Fallback posting guard read `options.pullRequestId` (original undefined)
    instead of local `pullRequestId` (updated with discovered ID).
+
+### Phase 10 -- Orchestrator Simplification (Done, v1.1.3)
+
+Branch: `fix/orchestrator-delete-old-comments`. Replaced AI-driven comment
+dedup with orchestrator-level cleanup. Major refactor:
+
+1. **Orchestrator-level comment cleanup**: Added `deletePreviousLumosComments()`
+   which runs before each attempt via Bitbucket REST API. Scans PR activities
+   for comments containing "Lumos -- Test Failure Analysis" and deletes them.
+2. **Removed `toolResults` tracking**: `readToolSuccess()`,
+   `extractDiscoveredPrId()`, `verifyCommentPosted()` all deleted. The
+   orchestrator no longer parses MCP tool results.
+3. **Fixed `isRunIncomplete()` no-action signal false positive**: Added
+   `!hasAnalysisTools` guard so the no-action signal only fires when the AI
+   hasn't used any analysis tools. Also added `list_pull_requests` to the
+   analysis tools check. Added `logger.info` diagnostic when no-action fires.
+4. **Simplified `CommentPostState`**: Removed `postedCommentText` and
+   `attemptedCommentText` fields. `extractCommentInfo()` now only checks
+   `toolsUsed` for `add_comment`.
+5. **Tests updated**: 10 tests passing in `test/orchestrator.test.ts`.
 
 ## Test Validation Results
 
@@ -197,6 +217,17 @@ comments when using find-by-branch:
   `get_pull_request` -> file reading -> `add_comment`. 164k input tokens,
   ~$0.50 per attempt. The duplicate was caused by the `find-by-branch`
   verification bug (fixed in Phase 9).
+- **Build 31** (2026-04-11, v1.1.2): 252 tests, 197 passed, 38 failed, 0 flaky.
+  Lumos posted single comment (duplicate fix working). Old comments NOT cleaned
+  up because `find-by-branch` still couldn't resolve to numeric PR ID for the
+  `deletePreviousLumosComments()` call.
+- **Build 33** (2026-04-12, v1.1.2): Comment not posted. Root cause: AI's
+  85-token text response matched the no-action signal check (`isRunIncomplete()`
+  line 464-472) which silently returned `false`, preventing retry. The AI had
+  not used any analysis tools. Fixed in v1.1.3.
+- **Build 35** (2026-04-12, v1.1.3): 233 tests, 195 passed, 38 failed, 3 flaky.
+  Lumos posted comment ID 1168599 successfully. Orchestrator-level cleanup and
+  no-action signal fix both working. First successful run with v1.1.3.
 
 **Key finding from Build 26**: The `maxTokens: 8192` in Lighthouse config
 was sufficient for this run (AI produced ~359 output tokens of tool calls +
@@ -263,8 +294,9 @@ Key findings across all runs:
 | Automated npm publish (v1.0.1)     | lumos      | Done         | --                  |
 | find-by-branch PR discovery        | lumos      | Done (1.1.0) | --                  |
 | Prompt size diagnostics            | lumos      | Done (1.1.1) | --                  |
-| find-by-branch verification fix    | lumos      | In PR        | Pending merge       |
-| Lighthouse PR dep `^1.1.1`         | lighthouse | Done         | --                  |
+| find-by-branch verification fix    | lumos      | Done (1.1.2) | --                  |
+| Orchestrator cleanup + signal fix  | lumos      | Done (1.1.3) | --                  |
+| Lighthouse PR dep `^1.1.3`         | lighthouse | Done         | --                  |
 | Lighthouse lockfile regen          | lighthouse | Done         | --                  |
 | Lighthouse maxTokens 8192->30000   | lighthouse | Done         | User commit pending |
 | `scripts/run-lumos.js`             | lighthouse | Done         | --                  |
@@ -275,6 +307,8 @@ Key findings across all runs:
 | Jenkinsfile AI sanity catch block  | lighthouse | Deferred     | Validate mock first |
 | `orchestrator.test.ts` type fixes  | lumos      | Done         | --                  |
 | Fix `hasCritical` false positive   | lumos      | Pending      | No                  |
+| Safe-to-merge comment (0 failures) | lumos      | Pending      | Needs PR lookup     |
+| Orchestrator PR lookup by branch   | lumos      | Pending      | No                  |
 | Two-pass analysis                  | lumos      | Not started  | No                  |
 | Structured output wiring           | lumos      | Not started  | No                  |
 
@@ -284,11 +318,11 @@ Key findings across all runs:
   falls back to `responseText` scanning which can match "PR-caused" in
   non-critical context. Runs 1, 3, 7 had false positives; runs 2, 4, 8 were
   correct. Not yet fixed.
-- **Duplicate comments on find-by-branch (FIXING)**: When PR ID is discovered
-  via branch, orchestrator couldn't verify the MCP `add_comment` succeeded,
-  causing a retry that posted a second identical comment. Fix in PR on branch
-  `fix/find-by-branch-verification`. Three root causes: MCP response parsing,
-  PR ID extraction, fallback guard variable.
+- **Duplicate comments on find-by-branch (RESOLVED in v1.1.2 + v1.1.3)**:
+  Fixed via MCP response parsing (v1.1.2) and orchestrator-level comment
+  cleanup (v1.1.3). Old comments from builds 26, 28, 31 still on PR #4638
+  because `deletePreviousLumosComments()` requires a numeric PR ID, and
+  `find-by-branch` doesn't resolve to one yet (pending Task 3).
 - **`posting.strategy: 'per-failure'` is dead code**: The config option exists
   in the Zod schema but is never implemented. Only `'single'` works.
 - **Fixtures not committed**: `fixtures/result-{4598,4610,4571,4638}.json` are

--- a/memory-bank/projectBrief.md
+++ b/memory-bank/projectBrief.md
@@ -8,7 +8,7 @@ technical details. Changes only when the project's fundamental scope shifts. -->
 
 - **Name**: Lumos
 - **Package**: `@juspay/lumos`
-- **Version**: 1.1.1 (latest published; 1.1.2 pending with verification fix)
+- **Version**: 1.1.3 (latest published)
 - **Repo**: `github.com/juspay/lumos`
 - **Branch**: `release`
 - **Language**: TypeScript (strict, ESM, Node >= 20.12)

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -135,62 +135,33 @@ each failure's spec file, title, error message, error location, truncated
 stack trace (30 lines max, 2000 chars max), and retry info formatted as
 "X/Y failed" (e.g., "2/3 failed").
 
-## MCP Tool Result Verification
+## Orchestrator-Level Comment Cleanup
 
-After the AI calls MCP tools, the orchestrator needs to determine if
-`add_comment` succeeded. The verification chain in `readToolSuccess()`:
+Before each `generate()` attempt, `deletePreviousLumosComments()` scans the
+PR for existing Lumos comments and deletes them via Bitbucket REST API. This
+replaces the previous approach of relying on the AI to delete old comments
+as part of its workflow.
 
 ```
-AI SDK toolResult object
-  { type: 'tool-result', toolCallId, toolName, args, result }
-                                                       |
-                                                       v
-  MCP CallToolResult (the `result` field)
-  { content: [{ type: 'text', text: '<JSON string>' }] }
-                                            |
-                                            v
-  Parsed JSON from text field
-  { message: 'Comment added successfully', comment: { id: 12345, ... } }
-                                                            |
-                                                            v
-  readToolSuccess() checks: comment.id is numeric -> return true
+Orchestrator (before generate())
+  |
+  v
+GET /rest/api/latest/projects/{ws}/repos/{repo}/pull-requests/{id}/activities?limit=500
+  |
+  v
+Filter: activity.action === 'COMMENTED' && comment.text includes 'Lumos -- Test Failure Analysis'
+  |
+  v
+DELETE /rest/api/latest/projects/{ws}/repos/{repo}/pull-requests/{id}/comments/{commentId}?version={version}
+  |
+  v
+generate() call (AI no longer handles dedup)
 ```
 
-Priority of checks in `readToolSuccess()`:
+Requirements:
 
-1. `record.success` (boolean)
-2. `record.isError` (boolean, inverted)
-3. `record.status` (string: 'success'/'ok'/'completed' vs 'error'/'failed')
-4. `record.error` (non-null -> failure)
-5. `record.result` (recurse)
-6. `record.commentId` or `record.id` (presence -> success)
-7. `record.comment.id` (nested object -> success)
-8. `record.content[]` (MCP format: parse JSON from text entries, recurse)
-
-If `readToolSuccess()` returns `undefined` (indeterminate), the orchestrator
-falls back to `verifyCommentPosted()` which calls the Bitbucket REST API to
-check if the comment text appears on the PR.
-
-## PR ID Discovery for find-by-branch
-
-When `pullRequestId` starts as `"find-by-branch"`, the AI discovers the real
-numeric PR ID via `list_pull_requests` and uses it in subsequent tool calls.
-The orchestrator extracts this discovered ID from `toolResults`:
-
-```typescript
-// extractDiscoveredPrId() scans tool call args for numeric pull_request_id
-const prToolNames = [
-  'add_comment',
-  'get_pull_request',
-  'get_pull_request_diff',
-];
-// Iterates toolResults, finds first matching tool with numeric args.pull_request_id
-// Returns as string (e.g., '4638') or undefined if not found
-```
-
-This extracted ID is used to update the local `pullRequestId` variable,
-enabling both `verifyCommentPosted()` (REST API check) and `postCommentFallback()`
-(REST API fallback) to work with the correct numeric PR ID.
+- Numeric PR ID (does not work with `find-by-branch` string)
+- Bitbucket credentials (`BITBUCKET_BASE_URL`, `BITBUCKET_USERNAME`, `BITBUCKET_TOKEN`)
 
 ## Key Interfaces
 
@@ -233,7 +204,6 @@ SessionData {
   toolsUsed: string[],
   tokenUsage?: TokenUsage,
   estimatedCost?: number,
-  postedCommentText?: string,
 }
 
 LumosConfig {
@@ -264,24 +234,24 @@ All errors extend `LumosError` and carry a machine-readable `code` plus a
 
 ## Design Decisions
 
-| Decision                                              | Rationale                                                                                                                                                                                                                                                                                                                                          |
-| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Autonomous agent (not structured output) for V1       | Agent can fetch files, read code, and reason about context. Structured output would need all context upfront.                                                                                                                                                                                                                                      |
-| Single comment (not per-failure)                      | Developers prefer one consolidated comment over N separate ones. Reduces noise.                                                                                                                                                                                                                                                                    |
-| `maxFailures` removed (was capped at 10)              | Real PR 4638 had 17 failures; capping at 10 missed 7. Token cost is acceptable (~230k for 17).                                                                                                                                                                                                                                                     |
-| Comment dedup via MCP `delete_comment`                | The Bitbucket MCP server DOES have `delete_comment`. AI deletes old Lumos comments as part of its workflow step 2.                                                                                                                                                                                                                                 |
-| Memory bank loaded from consumer's project root       | Lighthouse has failure-pattern files that give the AI project-specific context.                                                                                                                                                                                                                                                                    |
-| LiteLLM for local, Vertex for prod                    | LiteLLM proxy at `grid.ai.juspay.net` is fast and free for dev. Vertex is the stable production path (same as Yama).                                                                                                                                                                                                                               |
-| Retry loop (MAX_ATTEMPTS=2)                           | AI sometimes stops prematurely without posting. A second attempt usually succeeds.                                                                                                                                                                                                                                                                 |
-| Fallback REST posting                                 | If AI fails to call `add_comment` after all retries, orchestrator posts directly via Bitbucket REST API to guarantee the comment reaches the PR.                                                                                                                                                                                                   |
-| `hasCritical` detection from posted comment text      | Scan the posted comment for "PR-caused" verdicts. Non-deterministic edge case exists (false positive from response text scanning).                                                                                                                                                                                                                 |
-| `totalAttempts` + `failedAttempts` (not `retryCount`) | AI needs to know "2 of 3 attempts failed" not just "3 retries". The old `retryCount` was ambiguous and caused misclassification.                                                                                                                                                                                                                   |
-| Typed error hierarchy                                 | Enables callers to `catch` specific error types (e.g., `McpError` vs `ConfigError`) for different handling strategies.                                                                                                                                                                                                                             |
-| 3-layer config with Zod                               | YAML for project defaults, env vars for per-run overrides (Jenkins stages), Zod catches invalid config early.                                                                                                                                                                                                                                      |
-| Langfuse observability (optional)                     | Traces AI calls for cost monitoring and debugging. Disabled by default; enabled via config or env vars.                                                                                                                                                                                                                                            |
-| Branch-based PR discovery (`find-by-branch`)          | Matches Yama's pattern. Jenkins `CHANGE_ID` is unavailable in some contexts (manual trigger, non-multibranch). AI discovers PR via `list_pull_requests` using branch name. Fallback REST posting disabled when PR ID is non-numeric.                                                                                                               |
-| Extract discovered PR ID from tool call args          | After AI discovers the real PR via `list_pull_requests` and uses it in `get_pull_request`/`add_comment`, the orchestrator extracts the numeric ID from `toolResults[].args.pull_request_id`. This enables REST API verification and fallback posting to work correctly for find-by-branch scenarios.                                               |
-| MCP tool result verification via `readToolSuccess()`  | MCP servers return `CallToolResult` format: `{ content: [{ type: 'text', text: '<JSON>' }] }`. The `readToolSuccess()` method now parses the embedded JSON and checks for `comment.id` (nested under a `comment` object) as a success indicator. Without this, all MCP tool results appeared as "indeterminate" and triggered unnecessary retries. |
+| Decision                                              | Rationale                                                                                                                                                                                                                                                                                                |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Autonomous agent (not structured output) for V1       | Agent can fetch files, read code, and reason about context. Structured output would need all context upfront.                                                                                                                                                                                            |
+| Single comment (not per-failure)                      | Developers prefer one consolidated comment over N separate ones. Reduces noise.                                                                                                                                                                                                                          |
+| `maxFailures` removed (was capped at 10)              | Real PR 4638 had 17 failures; capping at 10 missed 7. Token cost is acceptable (~230k for 17).                                                                                                                                                                                                           |
+| Comment dedup via MCP `delete_comment`                | The Bitbucket MCP server DOES have `delete_comment`. AI deletes old Lumos comments as part of its workflow step 2.                                                                                                                                                                                       |
+| Memory bank loaded from consumer's project root       | Lighthouse has failure-pattern files that give the AI project-specific context.                                                                                                                                                                                                                          |
+| LiteLLM for local, Vertex for prod                    | LiteLLM proxy at `grid.ai.juspay.net` is fast and free for dev. Vertex is the stable production path (same as Yama).                                                                                                                                                                                     |
+| Retry loop (MAX_ATTEMPTS=2)                           | AI sometimes stops prematurely without posting. A second attempt usually succeeds.                                                                                                                                                                                                                       |
+| Fallback REST posting                                 | If AI fails to call `add_comment` after all retries, orchestrator posts directly via Bitbucket REST API to guarantee the comment reaches the PR.                                                                                                                                                         |
+| `hasCritical` detection from posted comment text      | Scan the posted comment for "PR-caused" verdicts. Non-deterministic edge case exists (false positive from response text scanning).                                                                                                                                                                       |
+| `totalAttempts` + `failedAttempts` (not `retryCount`) | AI needs to know "2 of 3 attempts failed" not just "3 retries". The old `retryCount` was ambiguous and caused misclassification.                                                                                                                                                                         |
+| Typed error hierarchy                                 | Enables callers to `catch` specific error types (e.g., `McpError` vs `ConfigError`) for different handling strategies.                                                                                                                                                                                   |
+| 3-layer config with Zod                               | YAML for project defaults, env vars for per-run overrides (Jenkins stages), Zod catches invalid config early.                                                                                                                                                                                            |
+| Langfuse observability (optional)                     | Traces AI calls for cost monitoring and debugging. Disabled by default; enabled via config or env vars.                                                                                                                                                                                                  |
+| Branch-based PR discovery (`find-by-branch`)          | Matches Yama's pattern. Jenkins `CHANGE_ID` is unavailable in some contexts (manual trigger, non-multibranch). AI discovers PR via `list_pull_requests` using branch name. Fallback REST posting disabled when PR ID is non-numeric.                                                                     |
+| Orchestrator-level comment cleanup                    | `deletePreviousLumosComments()` runs before each attempt via Bitbucket REST API. More reliable than relying on the AI to delete old comments as part of its workflow. Removed `readToolSuccess()`, `extractDiscoveredPrId()`, `verifyCommentPosted()` -- orchestrator no longer parses MCP tool results. |
+| Simplified verification (v1.1.3)                      | Instead of parsing MCP `CallToolResult` format to verify `add_comment` success, the orchestrator checks `toolsUsed.includes('add_comment')`. Combined with orchestrator-level cleanup, this eliminates the duplicate comment bug without complex result parsing.                                         |
 
 ## Release & Publishing Pattern
 
@@ -353,7 +323,8 @@ the version-bump commit. This matches neurolink's ordering.
 
 **Version history**: v1.0.0 published manually by Sachin. Automated OIDC
 publishing produces subsequent versions: v1.0.1 (MCP binary fix), v1.1.0
-(find-by-branch), v1.1.1 (prompt diagnostics).
+(find-by-branch), v1.1.1 (prompt diagnostics), v1.1.2 (duplicate comment fix),
+v1.1.3 (orchestrator cleanup).
 
 ### Jira Prefix Stripping
 

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -259,4 +259,5 @@ pnpm run lumos:analyze --type mock --pr-id ${prId} --workspace BZ --repository l
 | 1.0.1   | 2026-04 | MCP binary fix (local path), OIDC pipeline fix (npm@11)    | fix           |
 | 1.1.0   | 2026-04 | find-by-branch PR discovery                                | feat          |
 | 1.1.1   | 2026-04 | Prompt size diagnostic logging                             | feat          |
-| 1.1.2   | pending | Duplicate comment fix (MCP verification, PR ID extraction) | fix           |
+| 1.1.2   | 2026-04 | Duplicate comment fix (MCP verification, PR ID extraction) | fix           |
+| 1.1.3   | 2026-04 | Orchestrator cleanup, no-action signal fix                 | fix           |

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -119,7 +119,79 @@ export class LumosOrchestrator {
 
     // -- Early exit: no failures ---------------------------------------------
     if (failures.length === 0) {
-      logger.info('No failures found. Skipping AI analysis.');
+      logger.info('No failures found.');
+
+      // Resolve PR ID so we can clean up old comments and post safe-to-merge
+      let pullRequestId = options.pullRequestId ?? '';
+      const branch = options.branch ?? '';
+
+      if (!pullRequestId || pullRequestId === '0') {
+        if (branch) {
+          const resolved = await this.resolvePrIdByBranch(
+            options.workspace,
+            options.repository,
+            branch
+          );
+          if (resolved) {
+            pullRequestId = resolved;
+          }
+        }
+      }
+
+      const numericPrId =
+        pullRequestId &&
+        pullRequestId !== '0' &&
+        pullRequestId !== 'find-by-branch'
+          ? pullRequestId
+          : undefined;
+
+      if (numericPrId && !options.dryRun) {
+        // Clean up old Lumos comments (e.g., from a previous run that had failures)
+        const cleanup = await this.deletePreviousLumosComments(
+          options.workspace,
+          options.repository,
+          numericPrId
+        );
+        if (cleanup.deleted > 0) {
+          logger.info(
+            `Cleaned up ${cleanup.deleted} previous Lumos comment(s) before posting safe-to-merge.`
+          );
+        }
+
+        // Post safe-to-merge comment
+        const duration = this.formatDuration(stats.durationMs);
+        const safeComment =
+          `## Lumos -- Test Failure Analysis (${options.type} tests)\n\n` +
+          `**Verdict: SAFE TO MERGE**\n\n` +
+          `${stats.passed} passed | 0 failed | ${stats.flaky} flaky | ${duration}\n\n` +
+          `### Summary\n` +
+          `All tests passed. No failures detected.\n\n` +
+          `### Failures Caused by PR Changes\n\n` +
+          `No test failures were caused by this PR's changes.\n\n` +
+          `### Pre-existing / Flaky Tests\n\n` +
+          `No flaky or pre-existing failures detected.\n\n` +
+          `### Infrastructure Issues\n\n` +
+          `No infrastructure issues detected.\n\n` +
+          `---\n` +
+          `*Analyzed by Lumos v1 | 0 PR files reviewed*`;
+
+        const posted = await this.postCommentFallback(
+          options.workspace,
+          options.repository,
+          numericPrId,
+          safeComment
+        );
+
+        return {
+          failuresAnalyzed: 0,
+          commentsPosted: posted ? 1 : 0,
+          hasCritical: false,
+        };
+      }
+
+      logger.info(
+        'Skipping safe-to-merge comment (no numeric PR ID available).'
+      );
       return {
         failuresAnalyzed: 0,
         commentsPosted: 0,
@@ -133,10 +205,22 @@ export class LumosOrchestrator {
 
     if (!pullRequestId || pullRequestId === '0') {
       if (branch) {
-        pullRequestId = 'find-by-branch';
-        logger.info(
-          `No pullRequestId provided. AI will discover the PR from branch "${branch}".`
+        // Attempt to resolve the branch to a numeric PR ID via Bitbucket API.
+        // This is critical for comment cleanup, fallback posting, and
+        // safe-to-merge flows that all require a numeric PR ID.
+        const resolved = await this.resolvePrIdByBranch(
+          options.workspace,
+          options.repository,
+          branch
         );
+        if (resolved) {
+          pullRequestId = resolved;
+        } else {
+          pullRequestId = 'find-by-branch';
+          logger.info(
+            `Could not resolve PR from branch "${branch}". AI will discover the PR at runtime.`
+          );
+        }
       } else {
         logger.warn(
           'No pullRequestId or branch provided. The AI agent will not be able ' +
@@ -201,6 +285,7 @@ export class LumosOrchestrator {
     let postedCommentText: string | undefined;
     let attempts = 0;
     let incomplete = false;
+    let previousSummary: string | undefined;
 
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       attempts = attempt;
@@ -215,28 +300,44 @@ export class LumosOrchestrator {
           ? pullRequestId
           : undefined;
       if (numericPrIdForCleanup && !options.dryRun) {
-        const deleted = await this.deletePreviousLumosComments(
+        const cleanup = await this.deletePreviousLumosComments(
           options.workspace,
           options.repository,
           numericPrIdForCleanup
         );
-        if (deleted > 0) {
+        if (cleanup.deleted > 0) {
           logger.info(
-            `Cleaned up ${deleted} previous Lumos comment(s) before attempt ${attempt}.`
+            `Cleaned up ${cleanup.deleted} previous Lumos comment(s) before attempt ${attempt}.`
           );
+        }
+        // Capture previous summary only on the first attempt
+        if (attempt === 1 && cleanup.previousSummary) {
+          previousSummary = cleanup.previousSummary;
         }
       }
 
-      const inputText =
-        attempt === 1
-          ? userMessage
-          : userMessage +
+      let inputText: string;
+      if (attempt === 1) {
+        inputText = previousSummary
+          ? userMessage +
             '\n\n' +
-            'IMPORTANT: A previous attempt to analyze these failures stopped ' +
-            'prematurely without posting a PR comment. You MUST complete the ' +
-            'full workflow: fetch the PR, read files, analyze failures, and ' +
-            'POST a comment using add_comment. Do not stop until the comment ' +
-            'is posted.';
+            '## Previous Lumos Analysis (from prior CI run)\n' +
+            'The following is a summary of the most recent Lumos comment on ' +
+            'this PR. Use it as context -- if your new analysis agrees with ' +
+            'prior findings, you can reference them. If new failures appeared ' +
+            'or old ones were fixed, note the changes in your Summary section.\n\n' +
+            previousSummary
+          : userMessage;
+      } else {
+        inputText =
+          userMessage +
+          '\n\n' +
+          'IMPORTANT: A previous attempt to analyze these failures stopped ' +
+          'prematurely without posting a PR comment. You MUST complete the ' +
+          'full workflow: fetch the PR, read files, analyze failures, and ' +
+          'POST a comment using add_comment. Do not stop until the comment ' +
+          'is posted.';
+      }
 
       if (attempt > 1) {
         logger.warn(
@@ -702,18 +803,19 @@ export class LumosOrchestrator {
 
   /**
    * Fetch all comments on the PR via Bitbucket REST API, find any that start
-   * with "## Lumos" (case-insensitive), and delete them. This ensures only
-   * the latest analysis is visible and prevents comment accumulation across
-   * CI runs and retry attempts.
+   * with "## Lumos" (case-insensitive), capture a summary of the most recent
+   * one (for prior-run context), and delete them all. This ensures only the
+   * latest analysis is visible and prevents comment accumulation across CI
+   * runs and retry attempts.
    *
-   * This is done at the orchestrator level (not by the AI) because the AI
-   * does not reliably execute the DEDUPLICATE step from the system prompt.
+   * Returns the count of deleted comments and an optional compact summary
+   * of the most recent previous Lumos comment.
    */
   private async deletePreviousLumosComments(
     workspace: string,
     repository: string,
     pullRequestId: string
-  ): Promise<number> {
+  ): Promise<{ deleted: number; previousSummary?: string }> {
     const { headers, url } = this.getBitbucketCommentRequestDetails(
       workspace,
       repository,
@@ -721,7 +823,7 @@ export class LumosOrchestrator {
     );
 
     if (!headers || !url) {
-      return 0;
+      return { deleted: 0 };
     }
 
     try {
@@ -731,7 +833,7 @@ export class LumosOrchestrator {
         logger.warn(
           `Failed to fetch PR comments for cleanup: ${response.status} ${response.statusText}`
         );
-        return 0;
+        return { deleted: 0 };
       }
 
       const payload = (await response.json().catch(() => null)) as Record<
@@ -740,7 +842,7 @@ export class LumosOrchestrator {
       > | null;
 
       if (!payload) {
-        return 0;
+        return { deleted: 0 };
       }
 
       // Extract comment entries with their IDs and text
@@ -750,7 +852,7 @@ export class LumosOrchestrator {
           ? payload.comments
           : [];
 
-      const lumosComments: { id: number; version: number }[] = [];
+      const lumosComments: { id: number; version: number; text: string }[] = [];
       for (const entry of values) {
         if (!entry || typeof entry !== 'object') continue;
         const record = entry as Record<string, unknown>;
@@ -760,13 +862,24 @@ export class LumosOrchestrator {
           const version =
             typeof record.version === 'number' ? record.version : 0;
           if (typeof id === 'number') {
-            lumosComments.push({ id, version });
+            lumosComments.push({ id, version, text });
           }
         }
       }
 
       if (lumosComments.length === 0) {
-        return 0;
+        return { deleted: 0 };
+      }
+
+      // Capture a summary of the most recent Lumos comment (highest ID)
+      // before deleting. This gives the AI continuity between runs.
+      const mostRecent = lumosComments.reduce((a, b) => (a.id > b.id ? a : b));
+      const previousSummary = this.summarizeLumosComment(mostRecent.text);
+
+      if (previousSummary) {
+        logger.info(
+          `Captured summary of previous Lumos comment #${mostRecent.id} for context.`
+        );
       }
 
       logger.info(
@@ -798,10 +911,10 @@ export class LumosOrchestrator {
         }
       }
 
-      return deleted;
+      return { deleted, previousSummary };
     } catch (err) {
       logger.warn(`Error during Lumos comment cleanup: ${err}`);
-      return 0;
+      return { deleted: 0 };
     }
   }
 
@@ -890,6 +1003,13 @@ export class LumosOrchestrator {
     return undefined;
   }
 
+  private formatDuration(ms: number): string {
+    const totalSeconds = Math.round(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}m ${seconds}s`;
+  }
+
   private getBitbucketCommentRequestDetails(
     workspace: string,
     repository: string,
@@ -922,5 +1042,192 @@ export class LumosOrchestrator {
         Authorization: `Basic ${auth}`,
       },
     };
+  }
+
+  // -------------------------------------------------------------------------
+  // Resolve PR ID from branch name via Bitbucket REST API
+  // -------------------------------------------------------------------------
+
+  /**
+   * Look up the open pull request for a given branch using the Bitbucket
+   * Server REST API. Returns the numeric PR ID as a string, or undefined
+   * if no open PR is found or credentials are missing.
+   *
+   * Endpoint: GET /rest/api/latest/projects/{ws}/repos/{repo}/pull-requests
+   *           ?state=OPEN&at=refs/heads/{branch}
+   */
+  private async resolvePrIdByBranch(
+    workspace: string,
+    repository: string,
+    branch: string
+  ): Promise<string | undefined> {
+    const baseUrl =
+      process.env.BITBUCKET_BASE_URL ?? 'https://bitbucket.juspay.net';
+    const username = process.env.BITBUCKET_USERNAME;
+    const token = process.env.BITBUCKET_TOKEN;
+
+    if (!username || !token) {
+      logger.warn(
+        'Cannot resolve PR by branch: BITBUCKET_USERNAME or BITBUCKET_TOKEN not set.'
+      );
+      return undefined;
+    }
+
+    const refPath = `refs/heads/${branch}`;
+    const url =
+      `${baseUrl}/rest/api/latest/projects/${workspace}/repos/${repository}` +
+      `/pull-requests?state=OPEN&at=${encodeURIComponent(refPath)}`;
+
+    const auth = Buffer.from(`${username}:${token}`).toString('base64');
+
+    try {
+      logger.info(
+        `Resolving PR ID for branch "${branch}" via Bitbucket API...`
+      );
+
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${auth}`,
+        },
+      });
+
+      if (!response.ok) {
+        logger.warn(
+          `Failed to look up PRs by branch: ${response.status} ${response.statusText}`
+        );
+        return undefined;
+      }
+
+      const payload = (await response.json().catch(() => null)) as Record<
+        string,
+        unknown
+      > | null;
+
+      if (!payload) {
+        return undefined;
+      }
+
+      const values = Array.isArray(payload.values) ? payload.values : [];
+
+      if (values.length === 0) {
+        logger.warn(`No open PR found for branch "${branch}".`);
+        return undefined;
+      }
+
+      const prId = (values[0] as Record<string, unknown>).id;
+      if (typeof prId === 'number') {
+        logger.info(
+          `Resolved branch "${branch}" to PR #${prId}` +
+            (values.length > 1
+              ? ` (${values.length} open PRs found, using first)`
+              : '')
+        );
+        return String(prId);
+      }
+
+      logger.warn(`PR entry has no numeric id field.`);
+      return undefined;
+    } catch (err) {
+      logger.warn(`Error resolving PR by branch: ${err}`);
+      return undefined;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Summarize a previous Lumos comment into a compact context block
+  // -------------------------------------------------------------------------
+
+  /**
+   * Parse a Lumos comment (which follows the rigid format defined in the
+   * system prompt) and produce a compact ~10-line summary suitable for
+   * injecting into the AI's user message as prior-run context.
+   *
+   * Extracts: Verdict, stats line, Summary section text, and failure counts
+   * per category. Returns undefined if the comment cannot be parsed.
+   */
+  private summarizeLumosComment(commentText: string): string | undefined {
+    const lines: string[] = [];
+
+    // Verdict
+    const verdictMatch =
+      /\*?\*?Verdict:\s*(SAFE TO MERGE|NEEDS FIXES|REVIEW RECOMMENDED)\*?\*?/i.exec(
+        commentText
+      );
+    if (verdictMatch) {
+      lines.push(`- Verdict: ${verdictMatch[1].toUpperCase()}`);
+    }
+
+    // Stats line: "X passed | Y failed | Z flaky | duration"
+    const statsMatch =
+      /(\d+)\s+passed\s*\|\s*(\d+)\s+failed\s*\|\s*(\d+)\s+flaky\s*\|\s*(.+)/i.exec(
+        commentText
+      );
+    if (statsMatch) {
+      lines.push(
+        `- Stats: ${statsMatch[1]} passed | ${statsMatch[2]} failed | ${statsMatch[3]} flaky | ${statsMatch[4].trim()}`
+      );
+    }
+
+    // Summary section (text between "### Summary" and the next "###")
+    const summaryMatch = /###\s*Summary\s*\n([\s\S]*?)(?=\n###\s|$)/i.exec(
+      commentText
+    );
+    if (summaryMatch) {
+      const summaryText = summaryMatch[1].trim();
+      if (summaryText) {
+        lines.push(`- Summary: ${summaryText}`);
+      }
+    }
+
+    // Count failures per category by counting "####" sub-headings
+    const prCausedSection =
+      /###\s*Failures Caused by PR Changes\s*\n([\s\S]*?)(?=\n###\s|$)/i.exec(
+        commentText
+      );
+    if (prCausedSection) {
+      const sectionBody = prCausedSection[1];
+      if (/no test failures were caused/i.test(sectionBody)) {
+        lines.push('- PR-caused failures: 0');
+      } else {
+        const count = (sectionBody.match(/^####\s/gm) || []).length;
+        lines.push(`- PR-caused failures: ${count}`);
+      }
+    }
+
+    const flakySection =
+      /###\s*Pre-existing\s*\/\s*Flaky Tests\s*\n([\s\S]*?)(?=\n###\s|$)/i.exec(
+        commentText
+      );
+    if (flakySection) {
+      const sectionBody = flakySection[1];
+      if (/no flaky or pre-existing/i.test(sectionBody)) {
+        lines.push('- Pre-existing/Flaky: 0');
+      } else {
+        const count = (sectionBody.match(/^-\s+\*\*/gm) || []).length;
+        lines.push(`- Pre-existing/Flaky: ${count}`);
+      }
+    }
+
+    const infraSection =
+      /###\s*Infrastructure Issues\s*\n([\s\S]*?)(?=\n---|$)/i.exec(
+        commentText
+      );
+    if (infraSection) {
+      const sectionBody = infraSection[1];
+      if (/no infrastructure issues/i.test(sectionBody)) {
+        lines.push('- Infrastructure: 0');
+      } else {
+        const count = (sectionBody.match(/^-\s+\*\*/gm) || []).length;
+        lines.push(`- Infrastructure: ${count}`);
+      }
+    }
+
+    if (lines.length === 0) {
+      return undefined;
+    }
+
+    return lines.join('\n');
   }
 }

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -124,6 +124,43 @@ function writeFailingReport(): { projectRoot: string; reportPath: string } {
   return { projectRoot, reportPath };
 }
 
+function writePassingReport(): { projectRoot: string; reportPath: string } {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'lumos-orchestrator-'));
+  const reportPath = join(projectRoot, 'result.json');
+
+  writeFileSync(
+    reportPath,
+    JSON.stringify({
+      suites: [
+        {
+          title: 'Login suite',
+          file: 'tests/login.spec.ts',
+          specs: [
+            {
+              title: 'should pass',
+              ok: true,
+              tests: [
+                {
+                  results: [
+                    {
+                      status: 'passed',
+                      duration: 500,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      stats: { duration: 5000 },
+    }),
+    'utf-8'
+  );
+
+  return { projectRoot, reportPath };
+}
+
 function createOrchestrator(
   projectRoot: string,
   generateResult: GenerateApiResult
@@ -338,5 +375,395 @@ describe('AnalyzeOptions', () => {
     };
 
     expect(options.branch).toBeUndefined();
+  });
+});
+
+describe('summarizeLumosComment', () => {
+  it('extracts verdict, stats, summary, and failure counts', () => {
+    const orchestrator = new LumosOrchestrator() as unknown as {
+      summarizeLumosComment: (text: string) => string | undefined;
+    };
+
+    const summary = orchestrator.summarizeLumosComment(LUMOS_COMMENT);
+
+    expect(summary).toBeDefined();
+    expect(summary).toContain('Verdict: NEEDS FIXES');
+    expect(summary).toContain('0 passed | 1 failed | 0 flaky');
+    expect(summary).toContain('One failure is caused by this PR.');
+    expect(summary).toContain('PR-caused failures: 1');
+    expect(summary).toContain('Pre-existing/Flaky: 0');
+    expect(summary).toContain('Infrastructure: 0');
+  });
+
+  it('handles safe-to-merge comments', () => {
+    const orchestrator = new LumosOrchestrator() as unknown as {
+      summarizeLumosComment: (text: string) => string | undefined;
+    };
+
+    const safeComment =
+      `## Lumos -- Test Failure Analysis (mock tests)\n\n` +
+      `**Verdict: SAFE TO MERGE**\n\n` +
+      `10 passed | 0 failed | 0 flaky | 1m 30s\n\n` +
+      `### Summary\nAll tests passed. No failures detected.\n\n` +
+      `### Failures Caused by PR Changes\n\n` +
+      `No test failures were caused by this PR's changes.\n\n` +
+      `### Pre-existing / Flaky Tests\n\n` +
+      `No flaky or pre-existing failures detected.\n\n` +
+      `### Infrastructure Issues\n\n` +
+      `No infrastructure issues detected.\n\n` +
+      `---\n*Analyzed by Lumos v1 | 0 PR files reviewed*`;
+
+    const summary = orchestrator.summarizeLumosComment(safeComment);
+
+    expect(summary).toBeDefined();
+    expect(summary).toContain('Verdict: SAFE TO MERGE');
+    expect(summary).toContain('10 passed | 0 failed | 0 flaky');
+    expect(summary).toContain('PR-caused failures: 0');
+  });
+
+  it('returns undefined for non-Lumos text', () => {
+    const orchestrator = new LumosOrchestrator() as unknown as {
+      summarizeLumosComment: (text: string) => string | undefined;
+    };
+
+    expect(
+      orchestrator.summarizeLumosComment('just a random comment')
+    ).toBeUndefined();
+  });
+});
+
+describe('resolvePrIdByBranch', () => {
+  it('resolves branch to numeric PR ID', async () => {
+    const orchestrator = new LumosOrchestrator() as unknown as {
+      resolvePrIdByBranch: (
+        ws: string,
+        repo: string,
+        branch: string
+      ) => Promise<string | undefined>;
+    };
+
+    process.env.BITBUCKET_BASE_URL = 'https://bitbucket.example.com';
+    process.env.BITBUCKET_USERNAME = 'user';
+    process.env.BITBUCKET_TOKEN = 'token';
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            values: [{ id: 4638, title: 'Test PR' }],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+    );
+
+    const result = await orchestrator.resolvePrIdByBranch(
+      'BZ',
+      'lighthouse',
+      'feat/my-feature'
+    );
+
+    expect(result).toBe('4638');
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('at=refs%2Fheads%2Ffeat%2Fmy-feature'),
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('returns undefined when no open PR exists', async () => {
+    const orchestrator = new LumosOrchestrator() as unknown as {
+      resolvePrIdByBranch: (
+        ws: string,
+        repo: string,
+        branch: string
+      ) => Promise<string | undefined>;
+    };
+
+    process.env.BITBUCKET_BASE_URL = 'https://bitbucket.example.com';
+    process.env.BITBUCKET_USERNAME = 'user';
+    process.env.BITBUCKET_TOKEN = 'token';
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ values: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+
+    const result = await orchestrator.resolvePrIdByBranch(
+      'BZ',
+      'lighthouse',
+      'feat/no-pr'
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when credentials are missing', async () => {
+    const orchestrator = new LumosOrchestrator() as unknown as {
+      resolvePrIdByBranch: (
+        ws: string,
+        repo: string,
+        branch: string
+      ) => Promise<string | undefined>;
+    };
+
+    delete process.env.BITBUCKET_USERNAME;
+    delete process.env.BITBUCKET_TOKEN;
+
+    const result = await orchestrator.resolvePrIdByBranch(
+      'BZ',
+      'lighthouse',
+      'feat/test'
+    );
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('safe-to-merge flow', () => {
+  it('posts safe-to-merge comment when 0 failures and PR ID is available', async () => {
+    const { projectRoot, reportPath } = writePassingReport();
+    process.env.BITBUCKET_BASE_URL = 'https://bitbucket.example.com';
+    process.env.BITBUCKET_USERNAME = 'user';
+    process.env.BITBUCKET_TOKEN = 'token';
+
+    const orchestrator = createOrchestrator(projectRoot, {
+      content: '',
+      toolsUsed: [],
+      toolResults: [],
+      finishReason: 'stop',
+      usage: { input: 0, output: 0, total: 0 },
+    });
+
+    // Mock: no previous comments, and POST succeeds
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockImplementation((url: string, init?: Record<string, unknown>) => {
+          if (init?.method === 'GET') {
+            return Promise.resolve(
+              new Response(JSON.stringify({ values: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              })
+            );
+          }
+          if (init?.method === 'POST') {
+            return Promise.resolve(
+              new Response(JSON.stringify({ id: 999 }), {
+                status: 201,
+                headers: { 'Content-Type': 'application/json' },
+              })
+            );
+          }
+          return Promise.resolve(new Response('', { status: 404 }));
+        })
+    );
+
+    try {
+      const result = await orchestrator.analyze({
+        workspace: 'BZ',
+        repository: 'lighthouse',
+        pullRequestId: '4638',
+        reportPath,
+        type: 'mock',
+      });
+
+      expect(result.failuresAnalyzed).toBe(0);
+      expect(result.commentsPosted).toBe(1);
+      expect(result.hasCritical).toBe(false);
+      // AI should NOT have been called
+      expect(orchestrator['neurolink'].generate).not.toHaveBeenCalled();
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves PR by branch for safe-to-merge when pullRequestId is not provided', async () => {
+    const { projectRoot, reportPath } = writePassingReport();
+    process.env.BITBUCKET_BASE_URL = 'https://bitbucket.example.com';
+    process.env.BITBUCKET_USERNAME = 'user';
+    process.env.BITBUCKET_TOKEN = 'token';
+
+    const orchestrator = createOrchestrator(projectRoot, {
+      content: '',
+      toolsUsed: [],
+      toolResults: [],
+      finishReason: 'stop',
+      usage: { input: 0, output: 0, total: 0 },
+    });
+
+    let postCalled = false;
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockImplementation((url: string, init?: Record<string, unknown>) => {
+          // PR lookup by branch
+          if (
+            init?.method === 'GET' &&
+            typeof url === 'string' &&
+            url.includes('/pull-requests?')
+          ) {
+            return Promise.resolve(
+              new Response(JSON.stringify({ values: [{ id: 100 }] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              })
+            );
+          }
+          // Comments GET (for cleanup)
+          if (init?.method === 'GET') {
+            return Promise.resolve(
+              new Response(JSON.stringify({ values: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              })
+            );
+          }
+          // POST comment
+          if (init?.method === 'POST') {
+            postCalled = true;
+            return Promise.resolve(
+              new Response(JSON.stringify({ id: 999 }), {
+                status: 201,
+                headers: { 'Content-Type': 'application/json' },
+              })
+            );
+          }
+          return Promise.resolve(new Response('', { status: 404 }));
+        })
+    );
+
+    try {
+      const result = await orchestrator.analyze({
+        workspace: 'BZ',
+        repository: 'lighthouse',
+        branch: 'feat/my-branch',
+        reportPath,
+        type: 'mock',
+      });
+
+      expect(result.failuresAnalyzed).toBe(0);
+      expect(result.commentsPosted).toBe(1);
+      expect(postCalled).toBe(true);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('skips safe-to-merge when no PR ID can be resolved', async () => {
+    const { projectRoot, reportPath } = writePassingReport();
+    process.env.BITBUCKET_BASE_URL = 'https://bitbucket.example.com';
+    process.env.BITBUCKET_USERNAME = 'user';
+    process.env.BITBUCKET_TOKEN = 'token';
+
+    const orchestrator = createOrchestrator(projectRoot, {
+      content: '',
+      toolsUsed: [],
+      toolResults: [],
+      finishReason: 'stop',
+      usage: { input: 0, output: 0, total: 0 },
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ values: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+
+    try {
+      const result = await orchestrator.analyze({
+        workspace: 'BZ',
+        repository: 'lighthouse',
+        branch: 'feat/no-pr',
+        reportPath,
+        type: 'mock',
+      });
+
+      expect(result.failuresAnalyzed).toBe(0);
+      expect(result.commentsPosted).toBe(0);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('previous analysis context', () => {
+  it('injects previous summary into user message on attempt 1', async () => {
+    const { projectRoot, reportPath } = writeFailingReport();
+    process.env.BITBUCKET_BASE_URL = 'https://bitbucket.example.com';
+    process.env.BITBUCKET_USERNAME = 'user';
+    process.env.BITBUCKET_TOKEN = 'token';
+
+    const orchestrator = createOrchestrator(projectRoot, {
+      content: 'Analysis complete.',
+      toolsUsed: ['bitbucket.add_comment'],
+      toolResults: [
+        {
+          toolName: 'bitbucket.add_comment',
+          args: { comment_text: LUMOS_COMMENT },
+        },
+      ],
+      finishReason: 'stop',
+      usage: { input: 10, output: 5, total: 15 },
+    });
+
+    // Mock: GET comments returns a previous Lumos comment, then DELETE
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockImplementation((url: string, init?: Record<string, unknown>) => {
+          if (init?.method === 'GET') {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  values: [{ id: 50, version: 0, text: LUMOS_COMMENT }],
+                }),
+                { status: 200, headers: { 'Content-Type': 'application/json' } }
+              )
+            );
+          }
+          if (init?.method === 'DELETE') {
+            return Promise.resolve(new Response('', { status: 204 }));
+          }
+          return Promise.resolve(new Response('', { status: 404 }));
+        })
+    );
+
+    try {
+      await orchestrator.analyze({
+        workspace: 'BZ',
+        repository: 'lighthouse',
+        pullRequestId: '4638',
+        reportPath,
+        type: 'mock',
+      });
+
+      // Verify that the AI was called with previous analysis context
+      const generateCall = vi.mocked(orchestrator['neurolink'].generate).mock
+        .calls[0][0];
+      const inputText =
+        typeof generateCall.input === 'string'
+          ? generateCall.input
+          : (generateCall.input as { text: string }).text;
+
+      expect(inputText).toContain('Previous Lumos Analysis');
+      expect(inputText).toContain('Verdict: NEEDS FIXES');
+      expect(inputText).toContain('PR-caused failures: 1');
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Description

  Three interconnected features that complete the orchestrator-level PR lifecycle:

  1. **PR lookup by branch** — `resolvePrIdByBranch()` resolves the `find-by-branch` placeholder to a numeric PR ID via
  Bitbucket REST API (`GET /rest/api/latest/.../pull-requests?state=OPEN&at=refs/heads/{branch}`) before the analysis
  loop. This unlocks comment cleanup, fallback posting, and safe-to-merge flows that all require a numeric PR ID.

  2. **Previous analysis context** — Before deleting old Lumos comments, captures and summarizes the most recent one via
  `summarizeLumosComment()` (verdict, stats, summary text, failure counts per category into a compact ~10-line block). On
   attempt 1, this summary is injected into the AI's user message under a `## Previous Lumos Analysis` heading, giving
  the AI continuity between CI runs.

  3. **Safe-to-merge comment** — When 0 failures are detected, posts a structured **SAFE TO MERGE** comment directly via
  Bitbucket REST API (no AI call needed), after cleaning up old Lumos comments from previous runs that may have had
  failures.

  ## Lumos Area

  - [ ] Playwright report parsing
  - [x] AI prompt / analysis flow
  - [x] Bitbucket or Jira integration
  - [x] Comment posting / retry / fallback logic
  - [ ] Config / package / release tooling
  - [x] Tests / fixtures
  - [x] Documentation / memory bank

  ## Type of Change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [x] Test or fixture improvement
  - [ ] CI / release / tooling update

  ## Related Issues

  - Relates to orchestrator-level comment cleanup (v1.1.3)

  ## How Has This Been Tested?

  - [x] `pnpm lint`
  - [x] `pnpm test`
  - [x] `pnpm typecheck`
  - [ ] `pnpm run validate:all`
  - [ ] `pnpm test:local`

  **Test Configuration**:

  - Node version: 22
  - OS: macOS
  - 10 new unit tests covering: `resolvePrIdByBranch` (3 tests), `summarizeLumosComment` (3 tests), safe-to-merge flow (3
   tests), previous analysis context injection (1 test). 20 total passing.

  ## Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I updated the memory bank if project behavior or architecture changed

  ## Additional Context

  All three features depend on having a numeric PR ID upfront, which is why PR lookup by branch is the foundational
  piece. The `deletePreviousLumosComments()` return type changed from `Promise<number>` to `Promise<{ deleted: number;
  previousSummary?: string }>` to support capturing the summary before deletion.