### PR TITLE
fix: replace resolvePrIdByBranch with listPrsForBranch for correct PR…

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -153,13 +153,13 @@ export class LumosOrchestrator {
 
       if (!pullRequestId || pullRequestId === '0') {
         if (branch) {
-          const resolved = await this.resolvePrIdByBranch(
+          const prs = await listPrsForBranch(
             options.workspace,
             options.repository,
             branch
           );
-          if (resolved) {
-            pullRequestId = resolved;
+          if (prs.length > 0 && prs[0].id) {
+            pullRequestId = String(prs[0].id);
           }
         }
       }
@@ -234,13 +234,13 @@ export class LumosOrchestrator {
         // Attempt to resolve the branch to a numeric PR ID via Bitbucket API.
         // This is critical for comment cleanup, fallback posting, and
         // safe-to-merge flows that all require a numeric PR ID.
-        const resolved = await this.resolvePrIdByBranch(
+        const prs = await listPrsForBranch(
           options.workspace,
           options.repository,
           branch
         );
-        if (resolved) {
-          pullRequestId = resolved;
+        if (prs.length > 0 && prs[0].id) {
+          pullRequestId = String(prs[0].id);
         } else {
           pullRequestId = 'find-by-branch';
           logger.info(
@@ -571,12 +571,12 @@ export class LumosOrchestrator {
 
     if (!pullRequestId || pullRequestId === '0') {
       if (branch) {
-        const resolved = await this.resolvePrIdByBranch(
+        const prs = await listPrsForBranch(
           options.workspace,
           options.repository,
           branch
         );
-        if (resolved) pullRequestId = resolved;
+        if (prs.length > 0 && prs[0].id) pullRequestId = String(prs[0].id);
       }
     }
 
@@ -1881,97 +1881,6 @@ export class LumosOrchestrator {
         Authorization: `Basic ${auth}`,
       },
     };
-  }
-
-  // -------------------------------------------------------------------------
-  // Resolve PR ID from branch name via Bitbucket REST API
-  // -------------------------------------------------------------------------
-
-  /**
-   * Look up the open pull request for a given branch using the Bitbucket
-   * Server REST API. Returns the numeric PR ID as a string, or undefined
-   * if no open PR is found or credentials are missing.
-   *
-   * Endpoint: GET /rest/api/latest/projects/{ws}/repos/{repo}/pull-requests
-   *           ?state=OPEN&at=refs/heads/{branch}
-   */
-  private async resolvePrIdByBranch(
-    workspace: string,
-    repository: string,
-    branch: string
-  ): Promise<string | undefined> {
-    const baseUrl =
-      process.env.BITBUCKET_BASE_URL ?? 'https://bitbucket.juspay.net';
-    const username = process.env.BITBUCKET_USERNAME;
-    const token = process.env.BITBUCKET_TOKEN;
-
-    if (!username || !token) {
-      logger.warn(
-        'Cannot resolve PR by branch: BITBUCKET_USERNAME or BITBUCKET_TOKEN not set.'
-      );
-      return undefined;
-    }
-
-    const refPath = `refs/heads/${branch}`;
-    const url =
-      `${baseUrl}/rest/api/latest/projects/${workspace}/repos/${repository}` +
-      `/pull-requests?state=OPEN&at=${encodeURIComponent(refPath)}`;
-
-    const auth = Buffer.from(`${username}:${token}`).toString('base64');
-
-    try {
-      logger.info(
-        `Resolving PR ID for branch "${branch}" via Bitbucket API...`
-      );
-
-      const response = await fetch(url, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Basic ${auth}`,
-        },
-      });
-
-      if (!response.ok) {
-        logger.warn(
-          `Failed to look up PRs by branch: ${response.status} ${response.statusText}`
-        );
-        return undefined;
-      }
-
-      const payload = (await response.json().catch(() => null)) as Record<
-        string,
-        unknown
-      > | null;
-
-      if (!payload) {
-        return undefined;
-      }
-
-      const values = Array.isArray(payload.values) ? payload.values : [];
-
-      if (values.length === 0) {
-        logger.warn(`No open PR found for branch "${branch}".`);
-        return undefined;
-      }
-
-      const prId = (values[0] as Record<string, unknown>).id;
-      if (typeof prId === 'number') {
-        logger.info(
-          `Resolved branch "${branch}" to PR #${prId}` +
-            (values.length > 1
-              ? ` (${values.length} open PRs found, using first)`
-              : '')
-        );
-        return String(prId);
-      }
-
-      logger.warn(`PR entry has no numeric id field.`);
-      return undefined;
-    } catch (err) {
-      logger.warn(`Error resolving PR by branch: ${err}`);
-      return undefined;
-    }
   }
 
   // -------------------------------------------------------------------------

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -432,16 +432,8 @@ describe('summarizeLumosComment', () => {
   });
 });
 
-describe('resolvePrIdByBranch', () => {
+describe('resolvePrIdByBranch (via listPrsForBranch)', () => {
   it('resolves branch to numeric PR ID', async () => {
-    const orchestrator = new LumosOrchestrator() as unknown as {
-      resolvePrIdByBranch: (
-        ws: string,
-        repo: string,
-        branch: string
-      ) => Promise<string | undefined>;
-    };
-
     process.env.BITBUCKET_BASE_URL = 'https://bitbucket.example.com';
     process.env.BITBUCKET_USERNAME = 'user';
     process.env.BITBUCKET_TOKEN = 'token';
@@ -451,35 +443,32 @@ describe('resolvePrIdByBranch', () => {
       vi.fn().mockResolvedValue(
         new Response(
           JSON.stringify({
-            values: [{ id: 4638, title: 'Test PR' }],
+            values: [
+              {
+                id: 4638,
+                title: 'Test PR',
+                fromRef: { displayId: 'feat/my-feature' },
+                toRef: { displayId: 'main' },
+                links: {
+                  self: [{ href: 'https://bitbucket.example.com/pr/4638' }],
+                },
+              },
+            ],
           }),
           { status: 200, headers: { 'Content-Type': 'application/json' } }
         )
       )
     );
 
-    const result = await orchestrator.resolvePrIdByBranch(
-      'BZ',
-      'lighthouse',
-      'feat/my-feature'
-    );
+    const { listPrsForBranch } =
+      await import('../src/utils/bitbucket-utils.js');
+    const prs = await listPrsForBranch('BZ', 'lighthouse', 'feat/my-feature');
 
-    expect(result).toBe('4638');
-    expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining('at=refs%2Fheads%2Ffeat%2Fmy-feature'),
-      expect.objectContaining({ method: 'GET' })
-    );
+    expect(prs).toHaveLength(1);
+    expect(String(prs[0].id)).toBe('4638');
   });
 
-  it('returns undefined when no open PR exists', async () => {
-    const orchestrator = new LumosOrchestrator() as unknown as {
-      resolvePrIdByBranch: (
-        ws: string,
-        repo: string,
-        branch: string
-      ) => Promise<string | undefined>;
-    };
-
+  it('returns empty array when no open PR exists', async () => {
     process.env.BITBUCKET_BASE_URL = 'https://bitbucket.example.com';
     process.env.BITBUCKET_USERNAME = 'user';
     process.env.BITBUCKET_TOKEN = 'token';
@@ -494,34 +483,22 @@ describe('resolvePrIdByBranch', () => {
       )
     );
 
-    const result = await orchestrator.resolvePrIdByBranch(
-      'BZ',
-      'lighthouse',
-      'feat/no-pr'
-    );
+    const { listPrsForBranch } =
+      await import('../src/utils/bitbucket-utils.js');
+    const prs = await listPrsForBranch('BZ', 'lighthouse', 'feat/no-pr');
 
-    expect(result).toBeUndefined();
+    expect(prs).toHaveLength(0);
   });
 
-  it('returns undefined when credentials are missing', async () => {
-    const orchestrator = new LumosOrchestrator() as unknown as {
-      resolvePrIdByBranch: (
-        ws: string,
-        repo: string,
-        branch: string
-      ) => Promise<string | undefined>;
-    };
-
+  it('returns empty array when credentials are missing', async () => {
     delete process.env.BITBUCKET_USERNAME;
     delete process.env.BITBUCKET_TOKEN;
 
-    const result = await orchestrator.resolvePrIdByBranch(
-      'BZ',
-      'lighthouse',
-      'feat/test'
-    );
+    const { listPrsForBranch } =
+      await import('../src/utils/bitbucket-utils.js');
+    const prs = await listPrsForBranch('BZ', 'lighthouse', 'feat/test');
 
-    expect(result).toBeUndefined();
+    expect(prs).toHaveLength(0);
   });
 });
 
@@ -606,16 +583,29 @@ describe('safe-to-merge flow', () => {
         .fn()
         .mockImplementation((url: string, init?: Record<string, unknown>) => {
           // PR lookup by branch
-          if (
-            init?.method === 'GET' &&
-            typeof url === 'string' &&
-            url.includes('/pull-requests?')
-          ) {
+          if (typeof url === 'string' && url.includes('/pull-requests?')) {
             return Promise.resolve(
-              new Response(JSON.stringify({ values: [{ id: 100 }] }), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' },
-              })
+              new Response(
+                JSON.stringify({
+                  values: [
+                    {
+                      id: 100,
+                      title: 'Test PR',
+                      fromRef: { displayId: 'feat/my-branch' },
+                      toRef: { displayId: 'main' },
+                      links: {
+                        self: [
+                          { href: 'https://bitbucket.example.com/pr/100' },
+                        ],
+                      },
+                    },
+                  ],
+                }),
+                {
+                  status: 200,
+                  headers: { 'Content-Type': 'application/json' },
+                }
+              )
             );
           }
           // Comments GET (for cleanup)


### PR DESCRIPTION
## Description

  Fixes PR ID resolution by branch in all three flows (analyze, review, test generation). The private
   `resolvePrIdByBranch` method was broken on Bitbucket DC — it used `?at=refs/heads/{branch}` which
  the API interprets as a destination ref filter, not a source branch filter, always returning 0
  results. Replaced all call sites with the existing `listPrsForBranch` utility which correctly
  filters by `fromRef.displayId` client-side.

  ## Lumos Area

  - [ ] Playwright report parsing
  - [ ] AI prompt / analysis flow
  - [x] Bitbucket or Jira integration
  - [ ] Comment posting / retry / fallback logic
  - [ ] Config / package / release tooling
  - [x] Tests / fixtures
  - [ ] Documentation / memory bank

  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
  - [ ] Documentation update
  - [ ] Test or fixture improvement
  - [ ] CI / release / tooling update

  ## Related Issues

  - Relates to Lighthouse Jenkins integration where `CHANGE_ID` is null on manual builds, forcing
  branch-based PR resolution which was silently failing

  ## How Has This Been Tested?

  Debugged against real Jenkins build logs showing "No open PR found for branch" despite the PR
  existing on Bitbucket. Root cause confirmed via API behavior analysis.

  - [x] `pnpm run validate:all` — all 47 tests pass

  ## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes

  ## Additional Context

  `resolvePrIdByBranch` tests have been rewritten to test `listPrsForBranch` directly (the actual
  implementation). The safe-to-merge mock was updated with the correct `fromRef.displayId` shape that
   `listPrsForBranch` expects for client-side filtering.