### PR TITLE
fix: extend credential injection to git push

### DIFF
--- a/src/utils/git-utils.ts
+++ b/src/utils/git-utils.ts
@@ -14,6 +14,58 @@ function exec(command: string, cwd: string): string {
   return execSync(command, { cwd, encoding: 'utf-8', timeout: 30_000 }).trim();
 }
 
+/**
+ * Temporarily rewrites the remote URL to embed Bitbucket credentials, runs
+ * `action`, then restores the original URL via `finally`. Falls back to
+ * running `action` directly when credentials are absent or the remote URL
+ * does not match BITBUCKET_BASE_URL (e.g. SSH remotes).
+ */
+function withAuthedRemote(
+  remote: string,
+  cwd: string,
+  action: () => void
+): void {
+  const username = process.env.BITBUCKET_USERNAME;
+  const token = process.env.BITBUCKET_TOKEN;
+  const baseUrl = process.env.BITBUCKET_BASE_URL;
+
+  if (username && token && baseUrl) {
+    let host: string;
+    try {
+      host = new URL(baseUrl).host;
+    } catch {
+      logger.info(
+        'BITBUCKET_BASE_URL is malformed, skipping credential injection.'
+      );
+      action();
+      return;
+    }
+
+    const currentRemote = exec(`git remote get-url ${remote}`, cwd);
+    const authedUrl = currentRemote.replace(
+      `https://${host}`,
+      `https://${encodeURIComponent(username)}:${encodeURIComponent(token)}@${host}`
+    );
+
+    if (authedUrl === currentRemote) {
+      logger.info(
+        'Remote URL does not match BITBUCKET_BASE_URL host, skipping credential injection.'
+      );
+      action();
+      return;
+    }
+
+    exec(`git remote set-url ${remote} ${authedUrl}`, cwd);
+    try {
+      action();
+    } finally {
+      exec(`git remote set-url ${remote} ${currentRemote}`, cwd);
+    }
+  } else {
+    action();
+  }
+}
+
 export function getRepoRoot(): string {
   const workspace = process.env.WORKSPACE;
   if (workspace && existsSync(join(workspace, '.git'))) {
@@ -35,46 +87,7 @@ export function getCurrentBranch(cwd: string): string {
 
 export function gitFetch(remote: string, cwd: string): void {
   logger.info(`Fetching ${remote}...`);
-
-  const username = process.env.BITBUCKET_USERNAME;
-  const token = process.env.BITBUCKET_TOKEN;
-  const baseUrl = process.env.BITBUCKET_BASE_URL;
-
-  if (username && token && baseUrl) {
-    let host: string;
-    try {
-      host = new URL(baseUrl).host;
-    } catch {
-      logger.info(
-        `BITBUCKET_BASE_URL is malformed, skipping credential injection.`
-      );
-      exec(`git fetch ${remote}`, cwd);
-      return;
-    }
-
-    const currentRemote = exec(`git remote get-url ${remote}`, cwd);
-    const authedUrl = currentRemote.replace(
-      `https://${host}`,
-      `https://${encodeURIComponent(username)}:${encodeURIComponent(token)}@${host}`
-    );
-
-    if (authedUrl === currentRemote) {
-      logger.info(
-        `Remote URL does not match BITBUCKET_BASE_URL host, skipping credential injection.`
-      );
-      exec(`git fetch ${remote}`, cwd);
-      return;
-    }
-
-    exec(`git remote set-url ${remote} ${authedUrl}`, cwd);
-    try {
-      exec(`git fetch ${remote}`, cwd);
-    } finally {
-      exec(`git remote set-url ${remote} ${currentRemote}`, cwd);
-    }
-  } else {
-    exec(`git fetch ${remote}`, cwd);
-  }
+  withAuthedRemote(remote, cwd, () => exec(`git fetch ${remote}`, cwd));
 }
 
 export function gitCheckout(branch: string, cwd: string): void {
@@ -122,7 +135,9 @@ export function gitPush(
   const forceFlag = force ? ' --force-with-lease' : '';
   const noVerifyFlag = noVerify ? ' --no-verify' : '';
   logger.info(`Pushing ${branch}${force ? ' (force-with-lease)' : ''}...`);
-  exec(`git push -u origin ${branch}${forceFlag}${noVerifyFlag}`, cwd);
+  withAuthedRemote('origin', cwd, () =>
+    exec(`git push -u origin ${branch}${forceFlag}${noVerifyFlag}`, cwd)
+  );
 }
 
 /**

--- a/test/git-utils.test.ts
+++ b/test/git-utils.test.ts
@@ -10,7 +10,7 @@ vi.mock('node:fs', () => ({
   existsSync: vi.fn(() => true),
 }));
 
-const { gitFetch } = await import('../src/utils/git-utils.js');
+const { gitFetch, gitPush } = await import('../src/utils/git-utils.js');
 
 const str = (s: string) => ({ trim: () => s });
 
@@ -133,5 +133,65 @@ describe('gitFetch', () => {
     // should only call get-url + fetch — no set-url calls
     expect(calls).toHaveLength(2);
     expect(calls[1]).toBe('git fetch origin');
+  });
+});
+
+describe('gitPush', () => {
+  const cwd = '/repo';
+
+  beforeEach(() => {
+    execSyncMock.mockReset();
+    delete process.env.BITBUCKET_USERNAME;
+    delete process.env.BITBUCKET_TOKEN;
+    delete process.env.BITBUCKET_BASE_URL;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('injects credentials into remote URL before push and restores afterward', () => {
+    process.env.BITBUCKET_USERNAME = 'ci-user';
+    process.env.BITBUCKET_TOKEN = 'secret';
+    process.env.BITBUCKET_BASE_URL = 'https://bitbucket.example.com';
+
+    const originalUrl = 'https://bitbucket.example.com/BZ/lighthouse.git';
+    execSyncMock
+      .mockReturnValueOnce(str(originalUrl)) // get-url
+      .mockReturnValueOnce(str('')) // set-url (authed)
+      .mockReturnValueOnce(str('')) // push
+      .mockReturnValueOnce(str('')); // set-url (restore)
+
+    gitPush('test/my-branch', cwd);
+
+    const calls = execSyncMock.mock.calls.map((c) => c[0] as string);
+    expect(calls[0]).toBe('git remote get-url origin');
+    expect(calls[1]).toContain('ci-user');
+    expect(calls[1]).toContain('secret');
+    expect(calls[2]).toContain('git push -u origin test/my-branch');
+    expect(calls[3]).toBe(`git remote set-url origin ${originalUrl}`);
+    expect(calls[3]).not.toContain('secret');
+  });
+
+  it('restores remote URL even when push throws', () => {
+    process.env.BITBUCKET_USERNAME = 'ci-user';
+    process.env.BITBUCKET_TOKEN = 'secret';
+    process.env.BITBUCKET_BASE_URL = 'https://bitbucket.example.com';
+
+    const originalUrl = 'https://bitbucket.example.com/BZ/lighthouse.git';
+    execSyncMock
+      .mockReturnValueOnce(str(originalUrl)) // get-url
+      .mockReturnValueOnce(str('')) // set-url (authed)
+      .mockImplementationOnce(() => {
+        throw new Error('push failed');
+      }) // push fails
+      .mockReturnValueOnce(str('')); // set-url (restore)
+
+    expect(() => gitPush('test/my-branch', cwd)).toThrow('push failed');
+
+    const restoreCall = execSyncMock.mock.calls[3]?.[0] as string;
+    expect(restoreCall).toBeDefined();
+    expect(restoreCall).toContain(originalUrl);
+    expect(restoreCall).not.toContain('secret');
   });
 });


### PR DESCRIPTION
## Description

  git push also uses HTTPS and fails the same way as git fetch on Jenkins
  with no credential helper.

  Extracted the credential injection logic into a private `withAuthedRemote`
  helper and applied it to both `gitFetch` and `gitPush`. The helper:
  - Parses the host from BITBUCKET_BASE_URL
  - Rewrites the origin URL with encoded username:token
  - Runs the git operation
  - Restores the original URL via finally (guaranteed even on failure)
  - Falls back to plain execution if credentials are absent, URL is malformed,
    or the remote host doesn't match

  ## Lumos Area
  - [x] Bitbucket or Jira integration

  ## Type of Change
  - [x] Bug fix

  ## How Has This Been Tested?
  - [x] pnpm lint / typecheck / test — 55/55 pass
  - Jenkins run confirmed: fetch succeeded (v1.4.2), push failed (this fix)

  ## Checklist
  - [x] Self-reviewed
  - [x] No new warnings
  - [x] Tests added for push credential rewrite and restore-on-failure paths