### PR TITLE
fix: remote branch check credentials + lint/format before push + file preservation prompt

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -6,94 +6,44 @@ content below this comment block. Keep under 60 lines. -->
 
 ## Current Focus
 
-Branch: `feat/review-pr-mode`.
-PR review capability is implemented and now being refined for stale-comment
-cleanup reliability and clearer review verdict semantics.
+Branch: `fix/remote-branch-exists-credentials`.
+PR #36 open against `juspay/lumos` release. Three fixes for Jenkins test generation failures.
 
 ### What Changed (this session)
 
-- **Paginated stale-comment cleanup**: `deletePreviousLumosComments()` in
-  `src/orchestrator.ts` now walks all Bitbucket PR comment pages using
-  `start`, `limit`, `isLastPage`, and `nextPageStart`, instead of assuming
-  the first page contains all old Lumos comments.
-- **Cleanup behavior is more robust on busy PRs**: old `## Lumos...` comments
-  can now be found and deleted even when they have been pushed off page 1 by
-  high comment volume.
-- **Prompt workflow now explicitly deletes every stale review comment** before
-  posting a new one, so the AI instructions match the orchestrator cleanup
-  behavior.
-- **Review semantics now support `ADVISORY`** in addition to PASS / FAIL /
-  SKIP, allowing non-blocking issues to produce `⚠ Advisory` instead of
-  `❌ Changes Required`.
-- **Build and proof rules refined**:
-  - Build status `INPROGRESS` is now advisory, not a hard fail.
-  - CI/tooling-only changes may use logs or dry-run output as proof.
-  - Missing proof for CI/tooling-only changes is advisory, not blocking.
-- **Conventions lookup widened**: prompt now checks
-  `memory-bank/lumos/pr-review-conventions.md` first, then falls back to
-  `memory-bank/pr-review-conventions.md`.
-- **Comment format tightened**: posted review must stay under 40 lines, use
-  short notes cells, and emit a compact `Action required` section only when
-  there are fails or advisories.
+- **Auto-format generated test files before commit** (`src/orchestrator.ts`):
+  `formatAndLintGeneratedFiles()` uses `execFileSync` with `--no-install` (no shell
+  injection, no interactive installs). Runs `prettier --write` then `eslint --fix`
+  before `gitAdd` in createPr mode. Unfixable lint issues are logged, never block push.
+  Path traversal guard added: files outside repo root are skipped. Fixes CI failures
+  from AI-generated tabs/quotes (PR #4970 pattern).
+
+- **File preservation rules in test gen prompt** (`src/prompts/test-gen-prompt.ts`):
+  Seven concrete rules in WORKFLOW step 7 + "File preservation" section in SELF-REVIEW.
+  Key invariant: output must have ≥ original line/test/key count. Fixes:
+  - PR #4970: deleted 6 tests, replaced stable selectors with fragile ones
+  - PR #4971: deleted 2449 lines from MCP_TOOLS, only added 3 entries
 
 ### Recent Decisions
 
-- **Cleanup must not depend on the first Bitbucket page**: comment deletion
-  should behave correctly on large PRs with multi-page discussion threads.
-- **Advisory findings are first-class**: non-blocking gaps should stay visible
-  without forcing a merge-blocking verdict.
-- **Conventions remain optional and repo-agnostic**: Lumos supports either
-  root-level or `memory-bank/lumos/` convention files without hardcoding a
-  single repo layout.
-
-## Fix Mode Git Flow (fix/test-branch-base-commit)
-
-Two bugs fixed from Lighthouse Jenkins runs:
-
-**Bug 1: Stale index in amended commit**
-
-- Jenkins shallow checkout leaves index in previous workspace state.
-  `git checkout -B` moves HEAD but does NOT reset index/working tree.
-  `git commit --amend` captured stale config files (CLAUDE.md, Jenkinsfile, etc.).
-- Fix: `git reset --hard origin/<testBranch>` after checkout in `reviewTestPr`
-  and `generateForDevPr`.
-
-**Bug 2: Feature code absent at test runtime**
-
-- Test branch created from dev branch at generation time. Fix mode runs later
-  when dev branch has moved. Feature UI elements (`[data-pw="function-confirmation-card"]`)
-  don't exist in the test branch's frozen snapshot.
-- Fix: `git reset --hard origin/<targetBranch>` in `reviewTestPr` — in fix mode,
-  `sourceBranch` is the test branch itself; `targetBranch` is the feature/dev branch.
-  Reset to targetBranch ensures all feature code is present when Playwright runs.
-  Reset preferred over rebase — no conflict risk, no broken Jenkins workspace.
-
-**Also:** `gitFetch` now accepts optional `branch?` param —
-`git fetch origin <branch>` ensures the ref is available in shallow clones.
+- **Conservative preservation**: "Don't touch existing lines" — broken tests are visible,
+  silently deleted tests are not.
+- **Count-based invariants**: "Output must have 40+N keys" beats vague "preserve".
+- **Format before gitAdd**: Committed code is clean on first push; no amend needed.
 
 ## npm Version History
 
-| Version | Contents                                        | Published via |
-| ------- | ----------------------------------------------- | ------------- |
-| 1.0.0   | Initial release                                 | Manual        |
-| 1.0.1   | MCP binary fix                                  | OIDC auto     |
-| 1.1.0   | find-by-branch PR discovery                     | OIDC auto     |
-| 1.1.1   | Prompt size diagnostic logging                  | OIDC auto     |
-| 1.1.2   | Duplicate comment fix (MCP verification, PR ID) | OIDC auto     |
-| 1.1.3   | Orchestrator cleanup, no-action signal fix      | OIDC auto     |
-| 1.2.0   | PR lookup by branch, safe-to-merge, prior-run   | OIDC auto     |
-| 1.3.0   | Test generation v2                              | OIDC auto     |
-| 1.4.0   | PR-creation git flow refinements                | OIDC auto     |
-| 1.4.1   | Fix resolvePrIdByBranch broken branch lookup    | OIDC auto     |
-| 1.4.2   | Fix Bitbucket credential injection in gitFetch  | OIDC auto     |
-| 1.5.0   | PR review (10 checks, repo-agnostic)            | Pending       |
-| next    | Fix stale index + rebase in fix/generate mode   | Pending       |
+| Version | Contents                                       | Published via    |
+| ------- | ---------------------------------------------- | ---------------- |
+| 1.4.2   | Fix Bitbucket credential injection in gitFetch | OIDC auto        |
+| 1.5.0   | PR review (10 checks, repo-agnostic)           | Pending          |
+| next    | Lint/format before push + file preservation    | Pending (PR #36) |
+
+Full history in git log on `release`.
 
 ## Next Steps
 
-1. Merge `fix/test-branch-base-commit` to `release` → publish next patch
-2. Validate paginated comment cleanup on a real multi-page Bitbucket PR
-3. Smoke-test the new `⚠ Advisory` verdict path against CI/tooling-only changes
-4. Merge `feat/review-pr-mode` to `release` and publish v1.5.0
-5. Wire up `reviewPr()` in Lighthouse Jenkinsfile as a standalone review stage
-6. Consider surfacing `checksRun` / `allPassed` to block or warn in Jenkins pipeline
+1. Merge PR #36 (`fix/remote-branch-exists-credentials`) → `release` → publish patch
+2. Merge `feat/review-pr-mode` → `release` → publish v1.5.0
+3. Wire up `reviewPr()` in Lighthouse Jenkinsfile as a standalone review stage
+4. Validate regenerated tests for PRs #4970 and #4971 once fixes are published

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,5 +1,5 @@
 import { resolve, join } from 'node:path';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { NeuroLink } from '@juspay/neurolink';
 import { loadConfig, type LumosConfig } from './config.js';
 import { parsePlaywrightReport } from './parsers/playwright.js';
@@ -919,6 +919,13 @@ export class LumosOrchestrator {
             const filePaths: string[] = [];
             for (const file of testFiles) {
               const fullPath = resolve(repoRoot, file.filePath);
+              // Guard against path traversal from AI-generated paths
+              if (!fullPath.startsWith(repoRoot + '/')) {
+                logger.warn(
+                  `Skipping file outside repo root: ${file.filePath}`
+                );
+                continue;
+              }
               const dir = resolve(fullPath, '..');
               const { mkdirSync, writeFileSync } = await import('node:fs');
               mkdirSync(dir, { recursive: true });
@@ -926,6 +933,12 @@ export class LumosOrchestrator {
               filePaths.push(file.filePath);
               logger.info(`Wrote: ${file.filePath}`);
             }
+
+            // Auto-format generated files with prettier and eslint --fix before
+            // committing (createPr mode only — comment-only mode does not write
+            // files to disk). Purely deterministic — no AI call. Unfixable lint
+            // errors are surfaced in Jenkins logs for the AI fix loop.
+            this.formatAndLintGeneratedFiles(filePaths, repoRoot);
 
             // Validate + fix only in comment-only mode. In createPr mode the
             // tsc check runs against Lighthouse's tsconfig which cannot resolve
@@ -1179,6 +1192,11 @@ export class LumosOrchestrator {
       const filePaths: string[] = [];
       for (const file of fixed) {
         const fullPath = resolve(repoRoot, file.filePath);
+        // Guard against path traversal from AI-generated paths
+        if (!fullPath.startsWith(repoRoot + '/')) {
+          logger.warn(`Skipping file outside repo root: ${file.filePath}`);
+          continue;
+        }
         const dir = resolve(fullPath, '..');
         const { mkdirSync, writeFileSync } = await import('node:fs');
         mkdirSync(dir, { recursive: true });
@@ -1186,6 +1204,9 @@ export class LumosOrchestrator {
         filePaths.push(file.filePath);
         logger.info(`Fixed: ${file.filePath}`);
       }
+
+      // Auto-format fixed files before amending the commit.
+      this.formatAndLintGeneratedFiles(filePaths, repoRoot);
 
       gitAdd(filePaths, repoRoot);
       gitAmend(repoRoot); // --amend --no-edit: no new commits
@@ -1306,6 +1327,75 @@ export class LumosOrchestrator {
     }
 
     return hints;
+  }
+
+  /**
+   * Run prettier --write and eslint --fix on generated files before committing.
+   * This is a best-effort step — errors are logged but never throw, so a
+   * formatter failure cannot block the commit.
+   */
+  private formatAndLintGeneratedFiles(filePaths: string[], cwd: string): void {
+    if (filePaths.length === 0) return;
+
+    // 1. prettier --write — fixes tabs, spacing, trailing commas, quote style
+    try {
+      execFileSync(
+        'npx',
+        ['--no-install', 'prettier', '--write', '--', ...filePaths],
+        {
+          cwd,
+          encoding: 'utf-8',
+          stdio: 'pipe',
+          timeout: 30_000,
+        }
+      );
+      logger.info('prettier --write completed on generated files.');
+    } catch (err) {
+      const prettierOut =
+        err instanceof Error && 'stdout' in err
+          ? String((err as Record<string, unknown>).stdout)
+          : '';
+      const prettierErr =
+        err instanceof Error && 'stderr' in err
+          ? String((err as Record<string, unknown>).stderr)
+          : '';
+      const prettierMsg =
+        (prettierOut + prettierErr).trim() ||
+        (err instanceof Error ? err.message : String(err));
+      logger.warn(`prettier --write failed (non-fatal):\n${prettierMsg}`);
+    }
+
+    // 2. eslint --fix — fixes auto-fixable lint rules
+    try {
+      execFileSync(
+        'npx',
+        ['--no-install', 'eslint', '--fix', '--', ...filePaths],
+        {
+          cwd,
+          encoding: 'utf-8',
+          stdio: 'pipe',
+          timeout: 30_000,
+        }
+      );
+      logger.info('eslint --fix completed on generated files.');
+    } catch (err) {
+      // eslint exits non-zero when unfixable errors remain — that is expected.
+      // Log stdout + stderr so unfixable lint errors are visible in Jenkins logs.
+      const eslintOut =
+        err instanceof Error && 'stdout' in err
+          ? String((err as Record<string, unknown>).stdout)
+          : '';
+      const eslintErr =
+        err instanceof Error && 'stderr' in err
+          ? String((err as Record<string, unknown>).stderr)
+          : '';
+      const eslintMsg =
+        (eslintOut + eslintErr).trim() ||
+        (err instanceof Error ? err.message : String(err));
+      logger.warn(
+        `eslint --fix reported errors (unfixable rules remain):\n${eslintMsg}`
+      );
+    }
   }
 
   /**

--- a/src/prompts/test-gen-prompt.ts
+++ b/src/prompts/test-gen-prompt.ts
@@ -105,6 +105,33 @@ You have access to Bitbucket MCP tools:
    AND the existing handler you read in step 5. Generate exactly TWO files:
    - A thin spec file (tests/e2e/<feature>.spec.ts)
    - A thick handler file (tests/routes/<feature>/<handler>.ts)
+
+   CRITICAL — FILE MODIFICATION RULES:
+   When a file already exists in the repository (spec, handler, or mock file):
+   a. READ the FULL file content first using get_file_content.
+   b. COUNT existing test cases and functions before touching the file.
+      Your output MUST contain AT LEAST that many test cases and functions.
+      If the input file has 6 test cases and you are adding 2 new ones,
+      your output MUST have 8 test cases. Never fewer.
+   c. ONLY ADD new content (new functions, new imports, new object entries).
+      Do not touch existing lines. Do not generate tests for features that
+      are not part of the current PR's changes.
+   d. NEVER remove existing test cases, handler functions, or exports —
+      even if they seem unrelated to the current PR. They cover other features.
+   e. NEVER rewrite or replace existing selector expressions. If an existing
+      test uses page.getByTestId('x'), leave that line exactly as-is.
+      You may add NEW assertions alongside it, but do not touch existing ones.
+   f. When adding entries to an existing object (e.g. MCP_TOOLS, mock handlers),
+      append ONLY the new entries at the end of the object. Do NOT replace the
+      object. Do NOT remove any existing key-value pairs. The final object must
+      contain every key that was there before PLUS your new additions.
+      Example: MCP_TOOLS had 40 entries → your output must have 40 + N entries.
+   g. Output the COMPLETE file content: every original line PLUS your additions.
+      If the original file was 300 lines, your output must be ≥ 300 lines.
+      Shorter output is a signal that you deleted something — review before posting.
+
+   When a file does NOT exist yet — create it from scratch following the patterns.
+
    Generate ONLY the scenarios from your test plan (step 4). Do not add
    scenarios you did not plan. Do not skip planned scenarios.
 8. SELF-REVIEW before posting. Check every item in this checklist:
@@ -134,6 +161,13 @@ You have access to Bitbucket MCP tools:
    - Every scenario from step 4 is implemented.
    - No extra scenarios were added that weren't planned.
    - Assertions match what was planned in step 4b.
+   File preservation (for modified files):
+   - Count test cases in original file vs your output. Output must have MORE, never fewer.
+   - Count functions in original handler vs your output. Output must have MORE, never fewer.
+   - Count top-level keys in any modified mock object. Output must have MORE, never fewer.
+   - Verify you have not changed any existing selector expression (getByTestId, locator, etc.).
+   - If your output is shorter (in lines) than the original file, STOP — you deleted something.
+     Find what was removed and add it back before posting.
 9. POST a single comment with all generated test code using the format below.`);
 
   // -- TEST GENERATION GUIDELINES -------------------------------------------


### PR DESCRIPTION
## Summary

Three fixes addressing issues observed in Jenkins runs.

### Fix 1: remoteBranchExists missing credential injection

git ls-remote in Jenkins (no interactive terminal) fails with "fatal: could not read Username" when run without credentials. The error was silently caught, causing the function to return false even when the branch existed. This triggered the non-fast-forward push path.

Fix: Wrapped git ls-remote in withAuthedRemote — the same credential injection pattern used by gitFetch and gitPush.

### Fix 2: Auto-format and lint generated test files before commit

Generated test files were failing CI due to formatting (tabs vs spaces) and lint issues (unused variables). These blocked Playwright runs and broke the fix-mode trigger chain.

Fix: Added formatAndLintGeneratedFiles() called after AI writes test files in both generate mode and fix mode. Runs prettier --write + eslint --fix before gitAdd. Unfixable lint issues (e.g. unused vars) are logged as warnings but don't block the push.

### Fix 3: Prevent AI from deleting existing test file content

AI was rewriting entire handler files when instructed to "update" them — destroying thousands of lines of existing test coverage. Root cause: the generation prompt had no explicit preservation instruction.

Fix: Added CRITICAL FILE MODIFICATION RULES block to workflow step 7 in test-gen-prompt.ts. Instructs the AI to read full existing file content first, preserve all existing functions/imports/exports/test cases, and only append new content.

## Files Changed

- src/utils/git-utils.ts — remoteBranchExists wrapped in withAuthedRemote
- src/orchestrator.ts — formatAndLintGeneratedFiles() added and called in generate + fix modes
- src/prompts/test-gen-prompt.ts — FILE MODIFICATION RULES added to workflow step 7

## Tests

All 74 tests passing.