### PR TITLE
fix: pass source branch to get_file_content in test gen prompt

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -757,7 +757,8 @@ export class LumosOrchestrator {
     // -- Build prompts -------------------------------------------------------
     const testGenSystemPrompt = buildTestGenSystemPrompt(
       this.config,
-      this.projectRoot
+      this.projectRoot,
+      prMetadata.sourceBranch
     );
     const userMessage = buildTestGenUserMessage(
       prMetadata,
@@ -1110,7 +1111,8 @@ export class LumosOrchestrator {
 
     const systemPrompt = buildTestGenSystemPrompt(
       this.config,
-      this.projectRoot
+      this.projectRoot,
+      prMetadata.sourceBranch
     );
 
     // Build a focused fix prompt using the test result comment

--- a/src/prompts/test-gen-prompt.ts
+++ b/src/prompts/test-gen-prompt.ts
@@ -10,9 +10,19 @@ import type { ChangedFile, PrMetadata } from '../parsers/types.js';
 
 export function buildTestGenSystemPrompt(
   config: LumosConfig,
-  projectRoot: string
+  projectRoot: string,
+  sourceBranch?: string
 ): string {
   const sections: string[] = [];
+  // Sanitize branch name: strip control characters and quotes to prevent
+  // prompt injection and malformed tool call instructions.
+  // Re-check after sanitization: if stripping leaves an empty string, treat
+  // as undefined so the prompt falls back to the '<source-branch>' placeholder
+  // instead of emitting branch="" (which would trigger default-branch reads).
+  const sanitized = sourceBranch
+    ? sourceBranch.replace(/[\r\n\t"'`\\]/g, '').trim()
+    : '';
+  const safeBranch = sanitized.length > 0 ? sanitized : undefined;
 
   // -- ROLE ------------------------------------------------------------------
   sections.push(`[ROLE]
@@ -31,7 +41,10 @@ You have access to Bitbucket MCP tools:
 - get_pull_request: Fetch PR details including the full diff
 - get_pull_request_diff: Get the diff, optionally filtered to a specific file
 - list_pull_requests: List pull requests for a repository
-- get_file_content: Read source files from the repository
+- get_file_content: Read source files from the repository.
+  IMPORTANT: Always pass branch="${safeBranch ?? '<source-branch>'}" in every get_file_content call.
+  Without the branch parameter, Bitbucket reads from the default branch and will return "Not found"
+  for any file that was added or modified in this PR.
 - search_code: Search for patterns in the codebase
 - add_comment: Post a comment on the PR`);
 
@@ -55,6 +68,13 @@ You have access to Bitbucket MCP tools:
    - Pure refactor (same behavior, different code) -> explain why tests
      are not needed and skip generation
    - Style / config change -> skip, explain why
+   NEVER use the PR description's test result claims (e.g. "37/37 passing",
+   "tests already exist") as a reason to skip generation. Only skip if you
+   successfully read the actual test files via get_file_content and confirmed
+   the coverage yourself. If file reads fail, proceed with generation but
+   explicitly state in your test plan which files you could not read, note
+   that selectors are unverified, and flag the generated tests as requiring
+   manual verification before merge.
 4. PLAN the test scenarios BEFORE writing any code.
    You MUST output a structured test plan. Do NOT skip this step.
    For each testable change, write:
@@ -79,12 +99,14 @@ You have access to Bitbucket MCP tools:
    a. Use search_code to find a handler in tests/routes/ that covers a
       feature similar to the one being changed.
    b. Use get_file_content to read that handler file IN FULL.
+      Pass branch="${safeBranch ?? '<source-branch>'}" in the call.
    c. This is your structural reference. Match its import style, selector
       patterns, helper function patterns, and error handling approach.
    DO NOT SKIP THIS STEP. You cannot generate accurate tests without seeing
    how existing tests in this project are written.
 6. For each testable change:
    a. READ the component source using get_file_content.
+      Pass branch="${safeBranch ?? '<source-branch>'}" in the call.
       Extract ALL selector attributes. Search for:
       - use:testAttributes={'selector-name'} (Svelte action, most common)
       - data-pw="selector-name" (direct HTML attribute)
@@ -109,6 +131,8 @@ You have access to Bitbucket MCP tools:
    CRITICAL — FILE MODIFICATION RULES:
    When a file already exists in the repository (spec, handler, or mock file):
    a. READ the FULL file content first using get_file_content.
+      Pass branch="${safeBranch ?? '<source-branch>'}" in the call.
+      If the file is not found on the branch, treat it as a new file and create it from scratch.
    b. COUNT existing test cases and functions before touching the file.
       Your output MUST contain AT LEAST that many test cases and functions.
       If the input file has 6 test cases and you are adding 2 new ones,

--- a/test/test-generation.test.ts
+++ b/test/test-generation.test.ts
@@ -181,6 +181,41 @@ describe('buildTestGenSystemPrompt', () => {
     expect(prompt).not.toContain('SAFE TO MERGE');
     expect(prompt).not.toContain('NEEDS FIXES');
   });
+
+  it('injects sourceBranch into get_file_content instructions', () => {
+    const prompt = buildTestGenSystemPrompt(
+      makeConfig(),
+      tmpDir,
+      'feat/BZ-1234-my-feature'
+    );
+    expect(prompt).toContain('branch="feat/BZ-1234-my-feature"');
+  });
+
+  it('falls back to placeholder when sourceBranch is not provided', () => {
+    const prompt = buildTestGenSystemPrompt(makeConfig(), tmpDir);
+    expect(prompt).toContain('branch="<source-branch>"');
+    expect(prompt).not.toContain('branch="undefined"');
+  });
+
+  it('sanitizes sourceBranch to prevent prompt injection', () => {
+    const prompt = buildTestGenSystemPrompt(
+      makeConfig(),
+      tmpDir,
+      'feat/bad\nbranch"name'
+    );
+    // The sanitized branch value injected into the prompt should not contain
+    // the injected newline or quote from the branch name.
+    expect(prompt).toContain('branch="feat/badbranch');
+    expect(prompt).not.toContain('branch="feat/bad\n');
+  });
+
+  it('falls back to placeholder when sanitization produces an empty string', () => {
+    // A branch name composed entirely of stripped characters becomes empty
+    // after sanitization — must not emit branch="" which triggers default-branch reads.
+    const prompt = buildTestGenSystemPrompt(makeConfig(), tmpDir, '"\'\n\t\\');
+    expect(prompt).toContain('branch="<source-branch>"');
+    expect(prompt).not.toContain('branch=""');
+  });
 });
 
 describe('buildTestGenUserMessage', () => {


### PR DESCRIPTION
## Description

  Fix a root cause bug where `get_file_content` calls in the test generation prompt never passed the `branch` parameter.
  Without it, Bitbucket reads from the default branch — any file added or modified on the feature branch returns "Not
  found". This caused the AI to generate tests from scratch instead of reading the actual component source and existing
  test files, producing fabricated selectors (`button:has-text` instead of `data-pw`), collapsed test functions, missing
  `isMockingEnabled()` branching, and in some cases abandoning generation entirely by trusting PR description text as a
  coverage signal.

  Observed in Lighthouse PRs #5034, #5078, and #5079.

  ## Lumos Area

  - [x] AI prompt / analysis flow

  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)

  ## Related Issues

  - Relates to Lighthouse PRs #5034, #5078, #5079 (bad test generation caused by missing branch parameter)

  ## How Has This Been Tested?

  - [x] `pnpm lint`
  - [x] `pnpm test`
  - [x] `pnpm typecheck`

  All 74 existing tests pass. End-to-end verification requires triggering generation on a PR whose feature branch has
  new/modified test files and confirming the AI passes `branch=<source-branch>` in `get_file_content` calls (visible in
  verbose logs).

  **Test Configuration**:
  - Node version: 22
  - OS: macOS

  ## Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings
  - [x] New and existing unit tests pass locally with my changes

  ## Additional Context

  The `branch` parameter is injected into 4 places in `buildTestGenSystemPrompt`:
  1. `[AVAILABLE TOOLS]` — documents the parameter with an explicit warning
  2. Workflow step 5b — reading a reference handler file
  3. Workflow step 6a — reading component source to extract `data-pw` selectors
  4. Workflow step 7a — reading an existing test file before modifying it

  A fifth change adds a rule in step 3 prohibiting the AI from skipping generation based on PR description claims (e.g.
  "37/37 passing") — it must read the actual files to confirm coverage.